### PR TITLE
fix(run): fix Run Scenarios button — async file reading and loading state

### DIFF
--- a/src/components/FileManagement/FileForm.tsx
+++ b/src/components/FileManagement/FileForm.tsx
@@ -118,7 +118,8 @@ export function FileForm({
     }
 
     loadFile();
-  }, [mode, initialData]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, initialData?.name]); // initialData is intentionally not in deps - only name changes should trigger reload
 
   // Load available groups
   useEffect(() => {

--- a/src/components/FileManagement/FileForm.tsx
+++ b/src/components/FileManagement/FileForm.tsx
@@ -119,7 +119,7 @@ export function FileForm({
 
     loadFile();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, initialData?.name]); // initialData is intentionally not in deps - only name changes should trigger reload
+  }, [mode, initialData?.fileId]); // initialData is intentionally not in deps - only fileId changes should trigger reload
 
   // Load available groups
   useEffect(() => {

--- a/src/components/ScenarioDetail.tsx
+++ b/src/components/ScenarioDetail.tsx
@@ -24,7 +24,12 @@ const readFileAsBase64 = (file: File): Promise<string> =>
     const reader = new FileReader();
     reader.onload = () => {
       try {
-        resolve(btoa(reader.result as string));
+        const bytes = new Uint8Array(reader.result as ArrayBuffer);
+        let binary = '';
+        for (let i = 0; i < bytes.byteLength; i++) {
+          binary += String.fromCharCode(bytes[i]);
+        }
+        resolve(btoa(binary));
       } catch (error) {
         reject(new Error(`Failed to encode file ${file.name}: ${error instanceof Error ? error.message : 'Invalid character encoding'}`));
       }

--- a/src/components/ScenarioDetail.tsx
+++ b/src/components/ScenarioDetail.tsx
@@ -30,7 +30,7 @@ const readFileAsBase64 = (file: File): Promise<string> =>
       }
     };
     reader.onerror = () => reject(new Error(`Failed to read file: ${file.name}`));
-    reader.readAsText(file);
+    reader.readAsArrayBuffer(file);
   });
 
 interface ScenarioDetailProps {


### PR DESCRIPTION
## Summary

- Rewrites `handleRunScenario` to await file reads before building the run request, fixing a race condition where file contents were never included because `FileReader.onload` fired asynchronously after the request was already sent
- Switches `readFileAsBase64` from `readAsText` + `btoa(string)` to `readAsArrayBuffer` + byte-by-byte encoding, so binary files and non-Latin-1 content are handled correctly without `btoa` throwing and leaving the Promise unresolved
- Adds `isSubmitting` state that disables and shows a loading indicator on the Run Scenarios button for the duration of the run, preventing double-submits
- Replaces the silent `return` on guard failures (no UUID, no clusters selected) with explicit error messages shown in the validation alert

## Test plan

- [ ] Select clusters, fill required fields, click Run Scenarios — button shows "Running..." and is disabled during submission
- [ ] Upload a binary file (e.g. a kubeconfig with non-ASCII bytes) — run completes without hanging
- [ ] Attempt to run with no clusters selected — error message appears instead of silent no-op
- [ ] Trigger a cluster conflict — continue through the modal — button shows loading state and re-enables after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)