### PR TITLE
Add deploy preview for pull requests

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,76 @@
+name: Deploy Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        if: github.event.action != 'closed'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: github.event.action != 'closed'
+        run: npm ci
+
+      - name: Set deploy status to pending
+        if: github.event.action != 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              context: 'Deploy Preview',
+              description: 'Building preview...',
+            });
+
+      - name: Build for preview
+        if: github.event.action != 'closed'
+        run: npx vite build --base /${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/
+
+      - name: Inject preview banner
+        if: github.event.action != 'closed'
+        run: |
+          sed -i 's|<body>|<body><div style="background:#06c;color:#fff;padding:8px 16px;text-align:center;font-family:RedHatText,sans-serif;font-size:14px;position:sticky;top:0;z-index:9999">Deploy Preview — Backend API is not available in this environment</div>|' dist/index.html
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        id: preview
+        with:
+          source-dir: ./dist/
+
+      - name: Set deploy status to ready
+        if: github.event.action != 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'success',
+              target_url: '${{ steps.preview.outputs.preview-url }}',
+              context: 'Deploy Preview',
+              description: 'Preview is ready!',
+            });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/+$/, '')}>
       <AuthProvider>
         <AppProvider>
           <AppRouter />


### PR DESCRIPTION
## Summary
- Adds Netlify-style deploy previews using GitHub Pages + rossjrw/pr-preview-action
- Every PR gets a unique preview URL at `https://shahsahil264.github.io/krkn-operator-console/pr-preview/pr-<number>/`
- Commit status check with direct "Details" link to the preview
- Preview banner injected into builds noting API unavailability
- BrowserRouter basename fix for subdirectory routing
- Automatic cleanup when PR is closed/merged

## What this PR itself will test
Once merged, every future PR will get a deploy preview. This PR's own workflow run will be the first live test.

## One-time setup (already done)
- [x] GitHub Pages enabled on `gh-pages` branch
- [x] Workflow permissions set to "Read and write"

🤖 Generated with [Claude Code](https://claude.com/claude-code)