### PR TITLE
fix(ci): support deploy previews for fork PRs

### DIFF
--- a/.github/workflows/deploy-preview-publish.yml
+++ b/.github/workflows/deploy-preview-publish.yml
@@ -1,0 +1,195 @@
+name: Deploy Preview — Publish
+
+on:
+  workflow_run:
+    workflows: ["Deploy Preview — Build"]
+    types: [completed]
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+  actions: read
+
+jobs:
+  deploy:
+    if: >
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      (github.event_name == 'pull_request' && github.event.action == 'closed')
+    runs-on: ubuntu-24.04
+    concurrency:
+      group: preview-publish
+      cancel-in-progress: false
+    steps:
+      - name: Get PR info
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName === 'pull_request') {
+              core.setOutput('number', context.payload.pull_request.number);
+              core.setOutput('head_sha', context.payload.pull_request.head.sha);
+              core.setOutput('action', 'closed');
+              return;
+            }
+            // workflow_run event — find the PR
+            const prs = context.payload.workflow_run.pull_requests;
+            if (prs && prs.length > 0) {
+              core.setOutput('number', prs[0].number);
+              core.setOutput('head_sha', context.payload.workflow_run.head_sha);
+              core.setOutput('action', 'deploy');
+              return;
+            }
+            // Fallback: search for PR by head SHA
+            const { data: searchResult } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`,
+            });
+            if (searchResult.length > 0) {
+              core.setOutput('number', searchResult[0].number);
+              core.setOutput('head_sha', context.payload.workflow_run.head_sha);
+              core.setOutput('action', 'deploy');
+            } else {
+              core.setFailed('Could not find PR for this workflow run');
+            }
+
+      - name: Set deploy status to pending
+        if: steps.pr.outputs.action == 'deploy'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.pr.outputs.head_sha }}',
+              state: 'pending',
+              context: 'Deploy Preview',
+              description: 'Deploying preview...',
+            });
+
+      - name: Download preview artifact
+        if: steps.pr.outputs.action == 'deploy'
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-build-pr-${{ steps.pr.outputs.number }}
+          path: dist/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Deploy to gh-pages
+        if: steps.pr.outputs.action == 'deploy'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          destination_dir: pr-preview/pr-${{ steps.pr.outputs.number }}
+          keep_files: true
+
+      - name: Ensure support files on gh-pages
+        if: steps.pr.outputs.action == 'deploy'
+        run: |
+          AUTH_URL="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          TEMP=$(mktemp -d)
+          git clone --branch gh-pages --single-branch --depth 1 "$AUTH_URL" "$TEMP" 2>/dev/null || exit 0
+          cd "$TEMP"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          CHANGED=false
+          if [ ! -f .nojekyll ]; then touch .nojekyll; CHANGED=true; fi
+          if [ ! -f index.html ]; then
+            echo '<html><body>Deploy previews are served from subdirectories.</body></html>' > index.html
+            CHANGED=true
+          fi
+          if [ ! -f 404.html ]; then
+            cat > 404.html << 'SPAEOF'
+          <!DOCTYPE html><html><head><script>
+          var seg = window.location.pathname.match(/^(\/[^/]+\/pr-preview\/pr-\d+\/)/);
+          if (seg) { var rest = window.location.pathname.slice(seg[1].length);
+            window.location.replace(seg[1] + '?p=/' + rest + window.location.hash);
+          }
+          </script></head><body></body></html>
+          SPAEOF
+            CHANGED=true
+          fi
+          if [ "$CHANGED" = true ]; then
+            git add -A && git commit -m "Add GitHub Pages support files" && git push
+          fi
+
+      - name: Cleanup preview on close
+        if: steps.pr.outputs.action == 'closed'
+        run: |
+          AUTH_URL="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          TEMP=$(mktemp -d)
+          git clone --branch gh-pages --single-branch --depth 1 "$AUTH_URL" "$TEMP" 2>/dev/null || exit 0
+          cd "$TEMP"
+          PR_DIR="pr-preview/pr-${{ steps.pr.outputs.number }}"
+          if [ -d "$PR_DIR" ]; then
+            rm -rf "$PR_DIR"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A && git commit -m "Remove preview for PR #${{ steps.pr.outputs.number }}" && git push
+          fi
+
+      - name: Comment on PR
+        if: steps.pr.outputs.action == 'deploy'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const sha = '${{ steps.pr.outputs.head_sha }}'.substring(0, 7);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const previewUrl = `https://${owner}.github.io/${repo}/pr-preview/pr-${prNumber}/`;
+            const logoUrl = `https://raw.githubusercontent.com/${owner}/${repo}/main/public/logo.png`;
+
+            const body = [
+              '<!-- deploy-preview-bot -->',
+              `<img src="${logoUrl}" alt="krkn" width="20" align="top"> **Deploy Preview**`,
+              '',
+              '| Name | Detail |',
+              '|------|--------|',
+              `| **Preview URL** | [${previewUrl}](${previewUrl}) |`,
+              `| **Latest commit** | \`${sha}\` |`,
+              `| **Status** | :rocket: Ready |`,
+              '',
+              '> This is a static preview — API-dependent features use mock data.',
+            ].join('\n');
+
+            const marker = '<!-- deploy-preview-bot -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: prNumber,
+            });
+            const existing = comments.find(c =>
+              c.user.login === 'github-actions[bot]' && c.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            }
+
+      - name: Set deploy status
+        if: always() && steps.pr.outputs.action == 'deploy'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ steps.pr.outputs.number }};
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const previewUrl = `https://${owner}.github.io/${repo}/pr-preview/pr-${prNumber}/`;
+            const isSuccess = '${{ job.status }}' === 'success';
+            await github.rest.repos.createCommitStatus({
+              owner, repo,
+              sha: '${{ steps.pr.outputs.head_sha }}',
+              state: isSuccess ? 'success' : 'failure',
+              target_url: isSuccess ? previewUrl : '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
+              context: 'Deploy Preview',
+              description: isSuccess ? 'Preview is ready!' : 'Preview deployment failed',
+            });

--- a/.github/workflows/deploy-preview-publish.yml
+++ b/.github/workflows/deploy-preview-publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows: ["Deploy Preview — Build"]
     types: [completed]
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -17,7 +17,7 @@ jobs:
   deploy:
     if: >
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      (github.event_name == 'pull_request' && github.event.action == 'closed')
+      (github.event_name == 'pull_request_target' && github.event.action == 'closed')
     runs-on: ubuntu-24.04
     concurrency:
       group: preview-publish
@@ -28,7 +28,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            if (context.eventName === 'pull_request') {
+            if (context.eventName === 'pull_request_target') {
               core.setOutput('number', context.payload.pull_request.number);
               core.setOutput('head_sha', context.payload.pull_request.head.sha);
               core.setOutput('action', 'closed');
@@ -99,7 +99,14 @@ jobs:
         run: |
           AUTH_URL="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
           TEMP=$(mktemp -d)
-          git clone --branch gh-pages --single-branch --depth 1 "$AUTH_URL" "$TEMP" 2>/dev/null || exit 0
+
+          if git ls-remote --heads "$AUTH_URL" gh-pages | grep -q gh-pages; then
+            git clone --branch gh-pages --single-branch --depth 1 "$AUTH_URL" "$TEMP"
+          else
+            echo "::warning::gh-pages branch does not exist yet — support files will be added on next deploy"
+            exit 0
+          fi
+
           cd "$TEMP"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -129,7 +136,13 @@ jobs:
         run: |
           AUTH_URL="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
           TEMP=$(mktemp -d)
-          git clone --branch gh-pages --single-branch --depth 1 "$AUTH_URL" "$TEMP" 2>/dev/null || exit 0
+
+          if ! git ls-remote --heads "$AUTH_URL" gh-pages | grep -q gh-pages; then
+            echo "::warning::gh-pages branch does not exist — nothing to clean up"
+            exit 0
+          fi
+
+          git clone --branch gh-pages --single-branch --depth 1 "$AUTH_URL" "$TEMP"
           cd "$TEMP"
           PR_DIR="pr-preview/pr-${{ steps.pr.outputs.number }}"
           if [ -d "$PR_DIR" ]; then
@@ -137,6 +150,8 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add -A && git commit -m "Remove preview for PR #${{ steps.pr.outputs.number }}" && git push
+          else
+            echo "No preview directory found at $PR_DIR — already cleaned up"
           fi
 
       - name: Comment on PR

--- a/.github/workflows/deploy-preview-publish.yml
+++ b/.github/workflows/deploy-preview-publish.yml
@@ -34,27 +34,31 @@ jobs:
               core.setOutput('action', 'closed');
               return;
             }
-            // workflow_run event — find the PR
+            // workflow_run event — find the PR matching the exact head SHA
+            const headSha = context.payload.workflow_run.head_sha;
             const prs = context.payload.workflow_run.pull_requests;
             if (prs && prs.length > 0) {
-              core.setOutput('number', prs[0].number);
-              core.setOutput('head_sha', context.payload.workflow_run.head_sha);
+              const match = prs.find(pr => pr.head.sha === headSha) || prs[0];
+              core.setOutput('number', match.number);
+              core.setOutput('head_sha', headSha);
               core.setOutput('action', 'deploy');
               return;
             }
-            // Fallback: search for PR by head SHA
-            const { data: searchResult } = await github.rest.pulls.list({
+            // Fallback: search for PR by head branch, then verify SHA
+            const headLabel = `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`;
+            const { data: candidates } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
-              head: `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`,
+              head: headLabel,
             });
-            if (searchResult.length > 0) {
-              core.setOutput('number', searchResult[0].number);
-              core.setOutput('head_sha', context.payload.workflow_run.head_sha);
+            const match = candidates.find(pr => pr.head.sha === headSha);
+            if (match) {
+              core.setOutput('number', match.number);
+              core.setOutput('head_sha', headSha);
               core.setOutput('action', 'deploy');
             } else {
-              core.setFailed('Could not find PR for this workflow run');
+              core.setFailed(`No open PR with head ${headLabel} at SHA ${headSha}`);
             }
 
       - name: Set deploy status to pending

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,33 +1,26 @@
-name: Deploy Preview
+name: Deploy Preview — Build
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 concurrency:
-  group: deploy-preview-pr-${{ github.event.pull_request.number }}
+  group: preview-build-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
-
 jobs:
-  deploy-preview:
+  build-preview:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up Node.js
-        if: github.event.action != 'closed'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
       - name: Cache node_modules
-        if: github.event.action != 'closed'
         id: cache
         uses: actions/cache@v4
         with:
@@ -35,163 +28,23 @@ jobs:
           key: node-modules-${{ hashFiles('package-lock.json') }}
 
       - name: Install dependencies
-        if: github.event.action != 'closed' && steps.cache.outputs.cache-hit != 'true'
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Set deploy status to pending
-        if: github.event.action != 'closed'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: 'pending',
-              context: 'Deploy Preview',
-              description: 'Building preview...',
-            });
-
       - name: Build for preview
-        if: github.event.action != 'closed'
         env:
           VITE_PREVIEW_MODE: 'true'
         run: npx vite build --base /${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.pull_request.number }}/
 
       - name: Inject preview banner and SPA redirect
-        if: github.event.action != 'closed'
         run: |
           sed -i 's|</head>|<style>.quake-terminal-trigger{top:100px!important}.quake-terminal-backdrop{top:118px!important}.quake-terminal-panel{top:118px!important}.pf-v5-c-page__main{padding-top:38px!important}</style></head>|' dist/index.html
           sed -i 's|<body>|<body><div id="preview-banner" style="background:#06c;color:#fff;padding:6px 16px;text-align:center;font-family:RedHatText,sans-serif;font-size:13px;position:relative;z-index:0">Deploy Preview — Backend API is not available in this environment</div>|' dist/index.html
           sed -i 's|<head>|<head><script>(function(){var p=new URLSearchParams(window.location.search).get("p");if(p){window.history.replaceState(null,"",window.location.pathname.replace(/\\/$/,"")+p+window.location.hash);}})();</script>|' dist/index.html
 
-      - name: Deploy to gh-pages
-        if: github.event.action != 'closed'
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
-          destination_dir: pr-preview/pr-${{ github.event.pull_request.number }}
-          keep_files: true
-
-      - name: Ensure support files on gh-pages
-        if: github.event.action != 'closed'
-        run: |
-          AUTH_URL="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
-          TEMP=$(mktemp -d)
-          git clone --branch gh-pages --single-branch --depth 1 "$AUTH_URL" "$TEMP" 2>/dev/null || exit 0
-          cd "$TEMP"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          CHANGED=false
-
-          if [ ! -f .nojekyll ]; then touch .nojekyll; CHANGED=true; fi
-          if [ ! -f index.html ]; then
-            echo '<html><body>Deploy previews are served from subdirectories.</body></html>' > index.html
-            CHANGED=true
-          fi
-          if [ ! -f 404.html ]; then
-            cat > 404.html << 'SPAEOF'
-          <!DOCTYPE html><html><head><script>
-          var seg = window.location.pathname.match(/^(\/[^/]+\/pr-preview\/pr-\d+\/)/);
-          if (seg) { var rest = window.location.pathname.slice(seg[1].length);
-            window.location.replace(seg[1] + '?p=/' + rest + window.location.hash);
-          }
-          </script></head><body></body></html>
-          SPAEOF
-            CHANGED=true
-          fi
-
-          if [ "$CHANGED" = true ]; then
-            git add -A && git commit -m "Add GitHub Pages support files" && git push
-          fi
-
-      - name: Cleanup preview on close
-        if: github.event.action == 'closed'
-        run: |
-          AUTH_URL="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
-          TEMP=$(mktemp -d)
-          git clone --branch gh-pages --single-branch --depth 1 "$AUTH_URL" "$TEMP" 2>/dev/null || exit 0
-          cd "$TEMP"
-          PR_DIR="pr-preview/pr-${{ github.event.pull_request.number }}"
-          if [ -d "$PR_DIR" ]; then
-            rm -rf "$PR_DIR"
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add -A && git commit -m "Remove preview for PR #${{ github.event.pull_request.number }}" && git push
-          fi
-
-      - name: Comment on PR
-        if: github.event.action != 'closed'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const sha = context.payload.pull_request.head.sha.substring(0, 7);
-            const owner = context.payload.repository.owner.login;
-            const repo = context.payload.repository.name;
-            const previewUrl = `https://${owner}.github.io/${repo}/pr-preview/pr-${prNumber}/`;
-            const logoUrl = `https://raw.githubusercontent.com/${{ github.repository }}/main/public/logo.png`;
-
-            const body = [
-              '<!-- deploy-preview-bot -->',
-              `<img src="${logoUrl}" alt="krkn" width="20" align="top"> **Deploy Preview**`,
-              '',
-              '| Name | Detail |',
-              '|------|--------|',
-              `| **Preview URL** | [${previewUrl}](${previewUrl}) |`,
-              `| **Latest commit** | \`${sha}\` |`,
-              `| **Status** | :rocket: Ready |`,
-              '',
-              '> This is a static preview — API-dependent features use mock data.',
-            ].join('\n');
-
-            const marker = '<!-- deploy-preview-bot -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-
-            const existing = comments.find(c =>
-              c.user.login === 'github-actions[bot]' && c.body.includes(marker)
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body,
-              });
-            }
-
-      - name: Set deploy status
-        if: always() && github.event.action != 'closed'
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const owner = context.payload.repository.owner.login;
-            const repo = context.payload.repository.name;
-            const previewUrl = `https://${owner}.github.io/${repo}/pr-preview/pr-${prNumber}/`;
-            const isSuccess = '${{ job.status }}' === 'success';
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.pull_request.head.sha,
-              state: isSuccess ? 'success' : 'failure',
-              target_url: isSuccess ? previewUrl : '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}',
-              context: 'Deploy Preview',
-              description: isSuccess ? 'Preview is ready!' : 'Preview deployment failed',
-            });
+          name: preview-build-pr-${{ github.event.pull_request.number }}
+          path: dist/
+          retention-days: 1


### PR DESCRIPTION
## Summary

Fork PRs fail on deploy preview because GITHUB_TOKEN is read-only for fork PRs. This splits the workflow into two:

1. **Build** (`deploy-preview.yml`, `pull_request`) — builds the preview and uploads as artifact. No write access needed — works for both internal and fork PRs.
2. **Publish** (`deploy-preview-publish.yml`, `workflow_run`) — triggers after build completes, runs with upstream repo permissions. Downloads artifact, deploys to gh-pages, posts comment, sets status. Also handles cleanup on PR close.

Fixes: https://github.com/krkn-chaos/krkn-operator-console/actions/runs/29035906350

## Test plan
- [ ] Internal branch PR — build + publish both succeed
- [ ] Fork PR — build succeeds, publish deploys the preview
- [ ] PR close — preview cleaned up