### PR TITLE
fix(logs): show logs for failed runs that exhaust retries

### DIFF
--- a/src/components/JobsList.test.tsx
+++ b/src/components/JobsList.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { JobsList } from './JobsList';
+import type { ClusterJob, ClusterJobPhase, ScenarioRunState } from '../types/api';
+
+// The log viewer opens real WebSocket streams; stub it to a marker that records
+// the phase it was mounted with, so we can assert *which* phases show logs.
+vi.mock('./LogViewer', () => ({
+  LogViewer: ({ status }: { status: string }) => <div data-testid={`log-viewer-${status}`} />,
+}));
+// Unrelated children that would otherwise pull in pollers/modals.
+vi.mock('./ActiveRunsSummary', () => ({ ActiveRunsSummary: () => null }));
+vi.mock('./GraphRunDetail', () => ({ GraphRunDetail: () => null }));
+vi.mock('./FileManagement', () => ({ FileManagementModal: () => null }));
+vi.mock('../hooks/useRole', () => ({ useRole: () => ({ isAdmin: true }) }));
+vi.mock('../hooks/useActiveRunsPoller', () => ({
+  useActiveRunsPoller: () => ({ activeRuns: [], loading: false, error: null }),
+}));
+
+const makeJob = (phase: ClusterJobPhase, jobId: string): ClusterJob => ({
+  providerName: 'krkn-operator',
+  clusterName: 'cluster-a',
+  jobId,
+  podName: `pod-${jobId}`,
+  phase,
+});
+
+// One run holding a job in each phase we care about: an active one, the between-
+// attempts 'Retrying' state, a retries-exhausted terminal one, and a not-yet-started one.
+const run: ScenarioRunState = {
+  scenarioRunName: 'run-1',
+  scenarioName: 'pod-scenario',
+  phase: 'Running',
+  totalTargets: 4,
+  successfulJobs: 0,
+  failedJobs: 1,
+  runningJobs: 1,
+  createdAt: '2026-01-01T00:00:00Z',
+  clusterJobs: [
+    makeJob('Running', 'job-running'),
+    makeJob('Retrying', 'job-retrying'),
+    makeJob('MaxRetriesExceeded', 'job-terminal'),
+    makeJob('Pending', 'job-pending'),
+  ],
+};
+
+function renderJobsList() {
+  return render(
+    <JobsList
+      scenarioRuns={[run]}
+      expandedRunIds={new Set(['run-1'])}
+      expandedJobIds={new Set(['job-running', 'job-retrying', 'job-terminal', 'job-pending'])}
+      pausedPollingRunIds={new Set()}
+      onToggleRunAccordion={vi.fn()}
+      onToggleJobAccordion={vi.fn()}
+      onDeleteScenarioRun={vi.fn().mockResolvedValue(undefined)}
+      onDeleteJob={vi.fn().mockResolvedValue(undefined)}
+      onCreateJob={vi.fn()}
+      onRefreshScenarioRun={vi.fn()}
+      onNavigateToStudio={vi.fn()}
+      graphRuns={[]}
+      expandedGraphRunIds={new Set()}
+      pausedGraphPollingIds={new Set()}
+      onToggleGraphRunAccordion={vi.fn()}
+      onDeleteGraphRun={vi.fn().mockResolvedValue(undefined)}
+    />
+  );
+}
+
+describe('JobsList terminal-phase job UI', () => {
+  it('shows the log viewer for running, retrying, and terminal jobs, but not pending', () => {
+    renderJobsList();
+
+    // Pod has started (or finished) -> logs available.
+    expect(screen.getByTestId('log-viewer-Running')).toBeInTheDocument();
+    expect(screen.getByTestId('log-viewer-Retrying')).toBeInTheDocument();
+    // The regression this guards: a retries-exhausted job ends as 'MaxRetriesExceeded'
+    // (not 'Failed') and must still surface its logs.
+    expect(screen.getByTestId('log-viewer-MaxRetriesExceeded')).toBeInTheDocument();
+
+    // 'Pending' has no pod yet -> no log viewer.
+    expect(screen.queryByTestId('log-viewer-Pending')).not.toBeInTheDocument();
+  });
+
+  it('offers Delete only for non-terminal jobs', () => {
+    renderJobsList();
+
+    // Running, Retrying, Pending are non-terminal -> deletable; the terminal
+    // MaxRetriesExceeded job must not expose a delete control.
+    const deleteButtons = screen.getAllByRole('button', { name: /^Delete Job$/ });
+    expect(deleteButtons).toHaveLength(3);
+  });
+});

--- a/src/components/JobsList.tsx
+++ b/src/components/JobsList.tsx
@@ -71,6 +71,11 @@ type UnifiedRunItem =
     }
   | { type: 'scenario'; run: ScenarioRunState };
 
+// Job phases in which the pod has finished. A failed run that exhausts retries
+// ends as 'MaxRetriesExceeded' (not 'Failed'), so it must be included here or its
+// logs and terminal treatment get lost.
+const TERMINAL_JOB_PHASES: ClusterJobPhase[] = ['Succeeded', 'Failed', 'MaxRetriesExceeded', 'Cancelled', 'Stopped'];
+
 interface JobsListProps {
   scenarioRuns: ScenarioRunState[];
   expandedRunIds: Set<string>;
@@ -158,10 +163,19 @@ export function JobsList({
         return { icon: <HourglassHalfIcon />, color: 'orange' as const, label: 'Pending' };
       case 'Running':
         return { icon: <SyncAltIcon className="pf-m-spin" />, color: 'blue' as const, label: 'Running' };
+      case 'Retrying':
+        return { icon: <SyncAltIcon className="pf-m-spin" />, color: 'blue' as const, label: 'Retrying' };
       case 'Succeeded':
         return { icon: <CheckCircleIcon />, color: 'green' as const, label: 'Succeeded' };
       case 'Failed':
         return { icon: <ExclamationCircleIcon />, color: 'red' as const, label: 'Failed' };
+      case 'MaxRetriesExceeded':
+        // Terminal failure after all retries were exhausted - present it as a failure.
+        return { icon: <ExclamationCircleIcon />, color: 'red' as const, label: 'Failed (retries exhausted)' };
+      case 'Cancelled':
+        return { icon: <ExclamationTriangleIcon />, color: 'orange' as const, label: 'Cancelled' };
+      case 'Stopped':
+        return { icon: <ExclamationTriangleIcon />, color: 'grey' as const, label: 'Stopped' };
       default:
         return { icon: <ExclamationCircleIcon />, color: 'grey' as const, label: phase };
     }
@@ -1093,8 +1107,9 @@ export function JobsList({
                                             </div>
                                           </FlexItem>
 
-                                          {/* Logs for running, succeeded, and failed jobs */}
-                                          {['Running', 'Succeeded', 'Failed'].includes(job.phase) && (
+                                          {/* Logs for any job whose pod has started - running or terminal
+                                              (incl. failed/MaxRetriesExceeded/cancelled/stopped) */}
+                                          {(job.phase === 'Running' || TERMINAL_JOB_PHASES.includes(job.phase)) && (
                                             <FlexItem>
                                               <LogViewer
                                                 scenarioRunName={run.scenarioRunName}
@@ -1108,7 +1123,7 @@ export function JobsList({
                                           )}
 
                                           {/* Delete button for non-terminal jobs */}
-                                          {!['Succeeded', 'Failed'].includes(job.phase) && (
+                                          {!TERMINAL_JOB_PHASES.includes(job.phase) && (
                                             <FlexItem>
                                               <Button
                                                 variant="danger"

--- a/src/components/JobsList.tsx
+++ b/src/components/JobsList.tsx
@@ -1107,9 +1107,11 @@ export function JobsList({
                                             </div>
                                           </FlexItem>
 
-                                          {/* Logs for any job whose pod has started - running or terminal
-                                              (incl. failed/MaxRetriesExceeded/cancelled/stopped) */}
-                                          {(job.phase === 'Running' || TERMINAL_JOB_PHASES.includes(job.phase)) && (
+                                          {/* Logs for any job whose pod has started - running, retrying, or
+                                              terminal (incl. failed/MaxRetriesExceeded/cancelled/stopped).
+                                              'Pending' is the only phase with no pod yet, so it's the sole
+                                              phase without a log viewer. */}
+                                          {(job.phase === 'Running' || job.phase === 'Retrying' || TERMINAL_JOB_PHASES.includes(job.phase)) && (
                                             <FlexItem>
                                               <LogViewer
                                                 scenarioRunName={run.scenarioRunName}

--- a/src/components/LogViewer.test.tsx
+++ b/src/components/LogViewer.test.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LogViewer } from './LogViewer';
 import { authService } from '../services/authService';
 
@@ -39,9 +39,15 @@ class MockWebSocket {
 
 beforeEach(() => {
   MockWebSocket.instances = [];
-  (globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket;
+  // stubGlobal records the previous WebSocket so unstubAllGlobals can restore it,
+  // instead of leaving the mock installed on globalThis after this file's tests.
+  vi.stubGlobal('WebSocket', MockWebSocket);
   vi.clearAllMocks();
   (authService.getToken as ReturnType<typeof vi.fn>).mockReturnValue('test-token');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 describe('LogViewer terminal phase handling', () => {

--- a/src/components/LogViewer.test.tsx
+++ b/src/components/LogViewer.test.tsx
@@ -1,0 +1,80 @@
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LogViewer } from './LogViewer';
+import { authService } from '../services/authService';
+
+vi.mock('../services/authService', () => ({
+  authService: { getToken: vi.fn(() => 'test-token') },
+}));
+
+// Controllable WebSocket stub — jsdom has no WebSocket that connects to a server.
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: ((e: { code: number; reason?: string }) => void) | null = null;
+
+  constructor(public url: string, public protocol?: string) {
+    MockWebSocket.instances.push(this);
+    this.readyState = MockWebSocket.OPEN;
+    queueMicrotask(() => this.onopen?.());
+  }
+
+  send() {}
+  close(code = 1000, reason = '') {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code, reason });
+  }
+  emit(data: string) {
+    this.onmessage?.({ data });
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+  (globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket;
+  vi.clearAllMocks();
+  (authService.getToken as ReturnType<typeof vi.fn>).mockReturnValue('test-token');
+});
+
+describe('LogViewer terminal phase handling', () => {
+  // A run that fails and exhausts retries ends in job phase "MaxRetriesExceeded"
+  // (not "Failed"), so the log viewer must treat it as a completed/terminal job:
+  // fetch static logs once with follow=false and NOT open a follow stream.
+  it('fetches static logs (follow=false) for a MaxRetriesExceeded job', async () => {
+    render(
+      <LogViewer
+        scenarioRunName="run-1"
+        jobId="job-1"
+        clusterName="cluster-a"
+        podName="pod-xyz"
+        status="MaxRetriesExceeded"
+      />
+    );
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    expect(MockWebSocket.instances[0].url).toContain('follow=false');
+  });
+
+  it('fetches static logs (follow=false) for a Cancelled job', async () => {
+    render(
+      <LogViewer
+        scenarioRunName="run-2"
+        jobId="job-2"
+        clusterName="cluster-a"
+        podName="pod-abc"
+        status="Cancelled"
+      />
+    );
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1));
+    expect(MockWebSocket.instances[0].url).toContain('follow=false');
+  });
+});

--- a/src/components/LogViewer.tsx
+++ b/src/components/LogViewer.tsx
@@ -107,8 +107,15 @@ export function LogViewer({ scenarioRunName, jobId, clusterName, podName, status
       return;
     }
 
-    // If job is in terminal state, don't follow (get static logs)
-    const isTerminal = status === 'Succeeded' || status === 'Failed' || status === 'Stopped';
+    // If job is in a terminal state, don't follow (get static logs).
+    // A run that fails and exhausts retries ends as "MaxRetriesExceeded", and a
+    // cancelled one as "Cancelled" - both are terminal and must show their logs.
+    const isTerminal =
+      status === 'Succeeded' ||
+      status === 'Failed' ||
+      status === 'Stopped' ||
+      status === 'MaxRetriesExceeded' ||
+      status === 'Cancelled';
 
     if (!isTerminal) {
       setLogs(['Connecting to log stream...']);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -261,7 +261,19 @@ export interface JobsListResponse {
 // NEW API Types for ScenarioRun (CRD-based)
 
 export type ScenarioRunPhase = 'Pending' | 'Running' | 'Succeeded' | 'PartiallyFailed' | 'Failed';
-export type ClusterJobPhase = 'Pending' | 'Running' | 'Succeeded' | 'Failed';
+// Note: the operator emits more phases than the happy path. A failed job that
+// exhausts its retries ends as 'MaxRetriesExceeded', a user-cancelled one as
+// 'Cancelled', and a job is briefly 'Retrying' between attempts. The console
+// must handle all of these (see getJobPhaseDisplay and the log viewer).
+export type ClusterJobPhase =
+  | 'Pending'
+  | 'Running'
+  | 'Retrying'
+  | 'Succeeded'
+  | 'Failed'
+  | 'MaxRetriesExceeded'
+  | 'Cancelled'
+  | 'Stopped';
 
 export interface ClusterJob {
   providerName: string; // Provider that owns this cluster (e.g., 'krkn-operator', 'krkn-operator-acm')


### PR DESCRIPTION
## What & why

Logs for failed runs weren't showing up. When a run fails and exhausts its retries, the operator ends the job in phase `MaxRetriesExceeded` — **not** `Failed`. The console only knew about `Pending | Running | Succeeded | Failed`, so those runs fell through to the default case: no logs, no terminal treatment, and a stale delete button on a job that was actually done.

This adds the phases the operator actually emits and treats them correctly.

## Changes

- **`types/api.ts`** — widened `ClusterJobPhase` to the full set the operator emits: `Retrying`, `MaxRetriesExceeded`, `Cancelled`, `Stopped` (on top of the existing `Pending | Running | Succeeded | Failed`).
- **`JobsList.tsx`**
  - Added a single `TERMINAL_JOB_PHASES` constant so "show logs" and "allow delete" can't drift apart again.
  - Logs now render for any job whose pod has started — running **or** any terminal phase (including `MaxRetriesExceeded`).
  - Delete button is hidden for every terminal phase, not just`Succeeded`/`Failed`.
  - Added display (icon/color/label) for `Retrying`, `MaxRetriesExceeded` (shown as "Failed (retries exhausted)"), `Cancelled`, and `Stopped`.
- **`LogViewer.tsx`** — `MaxRetriesExceeded` and `Cancelled` are now treated as terminal, so the viewer fetches static logs once (`follow=false`) instead of trying to open a follow stream against a pod that's already gone.

## Tests

Added `LogViewer.test.tsx` covering the terminal-phase path — a`MaxRetriesExceeded` and a `Cancelled` job both fetch static logs with `follow=false` and don't open a follow stream.

## Screenshots
Below is a screenshot of how failed scenarios logs are appearing.

<img width="2764" height="1682" alt="image" src="https://github.com/user-attachments/assets/5ac37661-5bb9-4be4-8aa9-1e03b445f2d7" />


Fixes #11 