### PR TITLE
add field grouping, mutual exclusion, and scrollable/searchable group fields

### DIFF
--- a/src/components/DynamicFormBuilder.test.tsx
+++ b/src/components/DynamicFormBuilder.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { DynamicFormBuilder } from './DynamicFormBuilder';
+import type { ScenarioField, ScenarioFormValues } from '../types/api';
+
+function makeGroupField(variable: string, shortDesc: string, desc: string): ScenarioField {
+  return { name: variable, short_description: shortDesc, description: desc, variable, type: 'group', required: false, secret: false } as ScenarioField;
+}
+
+function makeEnumField(
+  variable: string,
+  shortDesc: string,
+  opts: { group?: string; mutually_excludes?: string; allowed_values?: string; default?: string; required?: boolean } = {},
+): ScenarioField {
+  return {
+    name: variable, short_description: shortDesc, description: `Desc for ${variable}`, variable,
+    type: 'enum', separator: ',', allowed_values: opts.allowed_values ?? 'a,b',
+    default: opts.default, required: opts.required ?? false, secret: false,
+    group: opts.group, mutually_excludes: opts.mutually_excludes,
+  } as ScenarioField;
+}
+
+function makeStringField(variable: string, shortDesc: string): ScenarioField {
+  return { name: variable, short_description: shortDesc, description: `Desc for ${variable}`, variable, type: 'string', required: false, secret: false } as ScenarioField;
+}
+
+describe('DynamicFormBuilder', () => {
+  describe('group rendering', () => {
+    it('should render group headers with title and description', () => {
+      const fields: ScenarioField[] = [
+        makeGroupField('G1', 'My Group', 'Group description text'),
+        makeEnumField('F1', 'Field 1', { group: 'G1' }),
+      ];
+      render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
+      expect(screen.getByText('My Group')).toBeInTheDocument();
+      expect(screen.getByText('Group description text')).toBeInTheDocument();
+    });
+
+    it('should render grouped fields inside their group container', () => {
+      const fields: ScenarioField[] = [
+        makeGroupField('G1', 'Group A', 'Desc'),
+        makeEnumField('F1', 'Field Inside Group', { group: 'G1' }),
+      ];
+      render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
+      expect(screen.getByText('Field Inside Group')).toBeInTheDocument();
+    });
+
+    it('should render ungrouped fields flat alongside groups', () => {
+      const fields: ScenarioField[] = [
+        makeStringField('UNGROUPED', 'Ungrouped Field'),
+        makeGroupField('G1', 'Group A', 'Desc'),
+        makeEnumField('F1', 'Grouped Field', { group: 'G1' }),
+      ];
+      render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
+      expect(screen.getByText('Ungrouped Field')).toBeInTheDocument();
+      expect(screen.getByText('Grouped Field')).toBeInTheDocument();
+    });
+  });
+
+  describe('group search', () => {
+    it('should filter fields by search input', async () => {
+      const user = userEvent.setup();
+      const fields: ScenarioField[] = [
+        makeGroupField('G1', 'Group', 'Desc'),
+        makeEnumField('ALPHA', 'Alpha Field', { group: 'G1' }),
+        makeEnumField('BETA', 'Beta Field', { group: 'G1' }),
+        makeEnumField('GAMMA', 'Gamma Field', { group: 'G1' }),
+      ];
+      render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
+
+      expect(screen.getByText('Alpha Field')).toBeInTheDocument();
+      expect(screen.getByText('Beta Field')).toBeInTheDocument();
+      expect(screen.getByText('Gamma Field')).toBeInTheDocument();
+
+      const searchInput = screen.getByPlaceholderText('Filter fields...');
+      await user.type(searchInput, 'beta');
+
+      expect(screen.queryByText('Alpha Field')).not.toBeInTheDocument();
+      expect(screen.getByText('Beta Field')).toBeInTheDocument();
+      expect(screen.queryByText('Gamma Field')).not.toBeInTheDocument();
+    });
+
+    it('should show empty message when search matches nothing', async () => {
+      const user = userEvent.setup();
+      const fields: ScenarioField[] = [
+        makeGroupField('G1', 'Group', 'Desc'),
+        makeEnumField('F1', 'Field 1', { group: 'G1' }),
+      ];
+      render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
+
+      const searchInput = screen.getByPlaceholderText('Filter fields...');
+      await user.type(searchInput, 'zzzzz');
+
+      expect(screen.getByText('No fields match your search.')).toBeInTheDocument();
+    });
+  });
+
+  describe('mutually_excludes', () => {
+    it('should disable excluded field when boolean enum is true', () => {
+      const fields: ScenarioField[] = [
+        makeEnumField('PROXY', 'Proxy', { allowed_values: 'true,false', mutually_excludes: 'SECRET' }),
+        makeEnumField('SECRET', 'Secret', { mutually_excludes: 'PROXY' }),
+      ];
+      const values: ScenarioFormValues = { PROXY: 'true', SECRET: 'a' };
+      render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
+
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      expect(secretSelect).toBeDisabled();
+    });
+
+    it('should not disable excluded field when boolean enum is false', () => {
+      const fields: ScenarioField[] = [
+        makeEnumField('PROXY', 'Proxy', { allowed_values: 'true,false', mutually_excludes: 'SECRET' }),
+        makeEnumField('SECRET', 'Secret', { mutually_excludes: 'PROXY' }),
+      ];
+      const values: ScenarioFormValues = { PROXY: 'false', SECRET: 'a' };
+      render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
+
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      expect(secretSelect).not.toBeDisabled();
+    });
+
+    it('should handle allowed_values with whitespace (e.g. "true, false")', () => {
+      const fields: ScenarioField[] = [
+        makeEnumField('PROXY', 'Proxy', { allowed_values: 'true, false', mutually_excludes: 'SECRET' }),
+        makeEnumField('SECRET', 'Secret', { mutually_excludes: 'PROXY' }),
+      ];
+      const values: ScenarioFormValues = { PROXY: 'true', SECRET: 'a' };
+      render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
+
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      expect(secretSelect).toBeDisabled();
+    });
+
+    it('should handle allowed_values with reversed order (e.g. "false,true")', () => {
+      const fields: ScenarioField[] = [
+        makeEnumField('PROXY', 'Proxy', { allowed_values: 'false,true', mutually_excludes: 'SECRET' }),
+        makeEnumField('SECRET', 'Secret', { mutually_excludes: 'PROXY' }),
+      ];
+      const values: ScenarioFormValues = { PROXY: 'true', SECRET: 'a' };
+      render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
+
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      expect(secretSelect).toBeDisabled();
+    });
+
+    it('should use default value for mutual exclusion when no explicit value', () => {
+      const fields: ScenarioField[] = [
+        makeEnumField('PROXY', 'Proxy', { allowed_values: 'true,false', default: 'true', mutually_excludes: 'SECRET' }),
+        makeEnumField('SECRET', 'Secret', { mutually_excludes: 'PROXY' }),
+      ];
+      render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
+
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      expect(secretSelect).toBeDisabled();
+    });
+
+    it('should reset excluded field value when exclusion activates', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      const fields: ScenarioField[] = [
+        makeEnumField('PROXY', 'Proxy', { allowed_values: 'true,false', default: 'false', mutually_excludes: 'SECRET' }),
+        makeEnumField('SECRET', 'Secret', { allowed_values: 'app-mgr,workmgr', default: 'app-mgr', mutually_excludes: 'PROXY' }),
+      ];
+      const values: ScenarioFormValues = { PROXY: 'false', SECRET: 'workmgr' };
+      render(<DynamicFormBuilder fields={fields} values={values} onChange={onChange} />);
+
+      const proxySelect = screen.getByRole('combobox', { name: /Proxy/i });
+      await user.selectOptions(proxySelect, 'true');
+
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+      expect(lastCall.SECRET).toBe('app-mgr');
+    });
+  });
+
+  describe('group fields excluded from form values', () => {
+    it('should not include group fields in onChange initial values', () => {
+      const onChange = vi.fn();
+      const fields: ScenarioField[] = [
+        makeGroupField('G1', 'Group', 'Desc'),
+        makeEnumField('F1', 'Field 1', { group: 'G1', default: 'a' }),
+      ];
+      render(<DynamicFormBuilder fields={fields} values={{}} onChange={onChange} />);
+
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+      expect(lastCall).not.toHaveProperty('G1');
+      expect(lastCall.F1).toBe('a');
+    });
+  });
+});

--- a/src/components/DynamicFormBuilder.test.tsx
+++ b/src/components/DynamicFormBuilder.test.tsx
@@ -105,7 +105,7 @@ describe('DynamicFormBuilder', () => {
       const values: ScenarioFormValues = { PROXY: 'true', SECRET: 'a' };
       render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
 
-      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i });
       expect(secretSelect).toBeDisabled();
     });
 
@@ -117,7 +117,7 @@ describe('DynamicFormBuilder', () => {
       const values: ScenarioFormValues = { PROXY: 'false', SECRET: 'a' };
       render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
 
-      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i });
       expect(secretSelect).not.toBeDisabled();
     });
 
@@ -129,7 +129,7 @@ describe('DynamicFormBuilder', () => {
       const values: ScenarioFormValues = { PROXY: 'true', SECRET: 'a' };
       render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
 
-      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i });
       expect(secretSelect).toBeDisabled();
     });
 
@@ -141,7 +141,7 @@ describe('DynamicFormBuilder', () => {
       const values: ScenarioFormValues = { PROXY: 'true', SECRET: 'a' };
       render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
 
-      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i });
       expect(secretSelect).toBeDisabled();
     });
 
@@ -152,7 +152,7 @@ describe('DynamicFormBuilder', () => {
       ];
       render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
 
-      const secretSelect = screen.getByRole('combobox', { name: /Secret/i }) as HTMLSelectElement;
+      const secretSelect = screen.getByRole('combobox', { name: /Secret/i });
       expect(secretSelect).toBeDisabled();
     });
 
@@ -166,11 +166,22 @@ describe('DynamicFormBuilder', () => {
       const values: ScenarioFormValues = { PROXY: 'false', SECRET: 'workmgr' };
       render(<DynamicFormBuilder fields={fields} values={values} onChange={onChange} />);
 
-      const proxySelect = screen.getByRole('combobox', { name: /Proxy/i });
-      await user.selectOptions(proxySelect, 'true');
+      const proxyToggle = screen.getByRole('checkbox', { name: /Proxy/i });
+      await user.click(proxyToggle);
 
       const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+      expect(lastCall.PROXY).toBe('true');
       expect(lastCall.SECRET).toBe('app-mgr');
+    });
+
+    it('should render boolean enum as a Switch toggle', () => {
+      const fields: ScenarioField[] = [
+        makeEnumField('TOGGLE', 'My Toggle', { allowed_values: 'true,false', default: 'false' }),
+      ];
+      render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
+
+      expect(screen.getByRole('checkbox', { name: /My Toggle/i })).toBeInTheDocument();
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/DynamicFormBuilder.tsx
+++ b/src/components/DynamicFormBuilder.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import {
   Form,
   FormGroup,
+  SearchInput,
   TextInput,
   FormSelect,
   FormSelectOption,
@@ -10,6 +11,7 @@ import {
   FormHelperText,
   HelperText,
   HelperTextItem,
+  Title,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import type { ScenarioField, ScenarioFormValues, StringField, EnumField } from '../types/api';
@@ -24,6 +26,23 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const initializedFieldsKey = useRef<string>('');
   const validationTimeouts = useRef<{ [key: string]: number }>({});
+
+  const disabledFields = useMemo(() => {
+    const disabled = new Set<string>();
+    for (const field of fields) {
+      if (
+        field.mutually_excludes &&
+        field.type === 'enum' &&
+        (field as EnumField).allowed_values === 'true,false'
+      ) {
+        const currentValue = values[field.variable] ?? field.default ?? '';
+        if (currentValue === 'true' || currentValue === true) {
+          disabled.add(field.mutually_excludes);
+        }
+      }
+    }
+    return disabled;
+  }, [fields, values]);
 
   /**
    * Safe regex test with timeout protection
@@ -65,6 +84,15 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
 
   const handleChange = (variable: string, value: string | number | boolean | File) => {
     const newValues = { ...values, [variable]: value };
+
+    const changedField = fields.find(f => f.variable === variable);
+    if (changedField?.mutually_excludes && (value === 'true' || value === true)) {
+      const excludedField = fields.find(f => f.variable === changedField.mutually_excludes);
+      if (excludedField) {
+        newValues[changedField.mutually_excludes] = excludedField.default ?? '';
+      }
+    }
+
     onChange(newValues);
 
     // Clear existing validation timeout for this field
@@ -97,14 +125,14 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
     }
   };
 
-  const renderField = (field: ScenarioField) => {
+  const renderField = (field: ScenarioField, isFieldDisabled: boolean = false) => {
     const value = values[field.variable] ?? field.default ?? '';
     const error = errors[field.variable];
     const validated = error ? 'error' : 'default';
 
     switch (field.type) {
       case 'string': {
-        const stringField = field as StringField; // Cast to access validator/validation_message
+        const stringField = field as StringField;
         return (
           <FormGroup
             key={field.variable}
@@ -120,6 +148,7 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
               validated={validated}
               placeholder={field.default}
               autoComplete={field.secret ? 'off' : undefined}
+              isDisabled={isFieldDisabled}
             />
             {field.description && (
               <FormHelperText>
@@ -165,6 +194,7 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
               onChange={(_event, val) => handleChange(field.variable, val)}
               validated={validated}
               placeholder={field.default}
+              isDisabled={isFieldDisabled}
             />
             {field.description && (
               <FormHelperText>
@@ -186,10 +216,8 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
         );
 
       case 'enum': {
-        // Type narrowing: cast to EnumField to access allowed_values and separator
         const enumField = field as EnumField;
 
-        // Validate that enum field has required properties
         if (!enumField.allowed_values || !enumField.separator) {
           return (
             <FormGroup
@@ -229,6 +257,7 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
               value={value as string}
               onChange={(_event, val) => handleChange(field.variable, val)}
               validated={validated}
+              isDisabled={isFieldDisabled}
             >
               {!field.required && <FormSelectOption key="empty" value="" label="Select an option" />}
               {options.map((option: string) => (
@@ -264,6 +293,7 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
               description={field.description}
               isChecked={value === true || value === 'true'}
               onChange={(_event, checked) => handleChange(field.variable, checked)}
+              isDisabled={isFieldDisabled}
             />
           </FormGroup>
         );
@@ -283,6 +313,7 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
               filename={(value as File)?.name || ''}
               onFileInputChange={(_event, file: File) => handleChange(field.variable, file)}
               validated={validated}
+              isDisabled={isFieldDisabled}
             />
             {field.description && (
               <FormHelperText>
@@ -319,14 +350,12 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
   // Initialize form values with defaults
   // Only initialize once per unique fields configuration
   useEffect(() => {
-    // Create a stable key from fields including defaults, types, and secret flags
-    // to detect changes to field metadata, not just variable names
-    const fieldsKey = fields
+    const valueFields = fields.filter(f => f.type !== 'group');
+    const fieldsKey = valueFields
       .map(f => `${f.variable}:${f.type}:${f.default}:${f.secret}`)
       .sort()
       .join(',');
 
-    // Skip if already initialized for these exact fields
     if (initializedFieldsKey.current === fieldsKey) {
       return;
     }
@@ -334,14 +363,124 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
     initializedFieldsKey.current = fieldsKey;
 
     const initialValues: ScenarioFormValues = {};
-    fields.forEach((field) => {
+    valueFields.forEach((field) => {
       if (field.default !== undefined) {
         initialValues[field.variable] = field.default;
       }
     });
     onChange({ ...initialValues, ...values });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fields]); // Only run when fields change, not when onChange or values change
+  }, [fields]);
 
-  return <Form>{fields.map((field) => renderField(field))}</Form>;
+  const groupMembers = useMemo(() => {
+    const members = new Map<string, ScenarioField[]>();
+    for (const field of fields) {
+      if (field.type !== 'group' && field.group) {
+        const list = members.get(field.group) || [];
+        list.push(field);
+        members.set(field.group, list);
+      }
+    }
+    return members;
+  }, [fields]);
+
+  return (
+    <Form>
+      {fields.map((field) => {
+        if (field.type === 'group') {
+          const members = groupMembers.get(field.variable) || [];
+          return (
+            <ScrollableFieldGroup
+              key={field.variable}
+              groupField={field}
+              members={members}
+              disabledFields={disabledFields}
+              renderField={renderField}
+            />
+          );
+        }
+        if (field.group) {
+          return null;
+        }
+        return renderField(field, disabledFields.has(field.variable));
+      })}
+    </Form>
+  );
+}
+
+const GROUP_CONTAINER_HEIGHT = 400;
+
+function ScrollableFieldGroup({
+  groupField,
+  members,
+  disabledFields,
+  renderField,
+}: {
+  groupField: ScenarioField;
+  members: ScenarioField[];
+  disabledFields: Set<string>;
+  renderField: (field: ScenarioField, isDisabled: boolean) => React.ReactNode;
+}) {
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    if (!search) return members;
+    const lower = search.toLowerCase();
+    return members.filter(
+      (m) =>
+        m.short_description.toLowerCase().includes(lower) ||
+        m.variable.toLowerCase().includes(lower)
+    );
+  }, [members, search]);
+
+  return (
+    <div
+      style={{
+        border: '1px solid var(--pf-v5-global--BorderColor--100)',
+        borderRadius: 'var(--pf-v5-global--BorderRadius--sm)',
+        marginBottom: '1rem',
+      }}
+    >
+      <div
+        style={{
+          borderLeft: '4px solid var(--pf-v5-global--primary-color--100)',
+          padding: '1rem 1.25rem',
+          borderBottom: '1px solid var(--pf-v5-global--BorderColor--100)',
+          background: 'var(--pf-v5-global--BackgroundColor--200)',
+        }}
+      >
+        <Title headingLevel="h2" size="xl" id={`group-${groupField.variable}-title`}>
+          {groupField.short_description}
+        </Title>
+        <p style={{ marginTop: '0.5rem', fontSize: 'var(--pf-v5-global--FontSize--sm)' }}>
+          {groupField.description}
+        </p>
+      </div>
+      <div style={{ padding: '1rem' }}>
+        <SearchInput
+          placeholder="Filter fields..."
+          value={search}
+          onChange={(_event, value) => setSearch(value)}
+          onClear={() => setSearch('')}
+          style={{ marginBottom: '0.75rem' }}
+        />
+        <div
+          style={{
+            maxHeight: `${GROUP_CONTAINER_HEIGHT}px`,
+            overflowY: 'auto',
+          }}
+        >
+          {filtered.length > 0 ? (
+            filtered.map((m) => renderField(m, disabledFields.has(m.variable)))
+          ) : (
+            <FormHelperText>
+              <HelperText>
+                <HelperTextItem>No fields match your search.</HelperTextItem>
+              </HelperText>
+            </FormHelperText>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/DynamicFormBuilder.tsx
+++ b/src/components/DynamicFormBuilder.tsx
@@ -12,6 +12,7 @@ import {
   HelperText,
   HelperTextItem,
   Title,
+  Switch,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import type { ScenarioField, ScenarioFormValues, StringField, EnumField } from '../types/api';
@@ -248,6 +249,30 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
         }
 
         const options = enumField.allowed_values.split(enumField.separator).map((opt: string) => opt.trim());
+        const sortedOpts = [...options].sort();
+        const isBooleanEnum = sortedOpts.length === 2 && sortedOpts[0] === 'false' && sortedOpts[1] === 'true';
+
+        if (isBooleanEnum) {
+          return (
+            <FormGroup key={field.variable} fieldId={field.variable}>
+              <Switch
+                id={field.variable}
+                label={field.short_description}
+                isChecked={value === 'true' || value === true}
+                onChange={(_event, checked) => handleChange(field.variable, checked ? 'true' : 'false')}
+                isDisabled={isFieldDisabled}
+              />
+              {field.description && (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem>{field.description}</HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              )}
+            </FormGroup>
+          );
+        }
+
         return (
           <FormGroup
             key={field.variable}

--- a/src/components/DynamicFormBuilder.tsx
+++ b/src/components/DynamicFormBuilder.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo, type ReactNode } from 'react';
 import {
   Form,
   FormGroup,
@@ -30,14 +30,17 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
   const disabledFields = useMemo(() => {
     const disabled = new Set<string>();
     for (const field of fields) {
-      if (
-        field.mutually_excludes &&
-        field.type === 'enum' &&
-        (field as EnumField).allowed_values === 'true,false'
-      ) {
-        const currentValue = values[field.variable] ?? field.default ?? '';
-        if (currentValue === 'true' || currentValue === true) {
-          disabled.add(field.mutually_excludes);
+      if (field.mutually_excludes && field.type === 'enum') {
+        const enumField = field as EnumField;
+        const opts = enumField.allowed_values
+          .split(enumField.separator)
+          .map((o) => o.trim())
+          .sort();
+        if (opts.length === 2 && opts[0] === 'false' && opts[1] === 'true') {
+          const currentValue = values[field.variable] ?? field.default ?? '';
+          if (currentValue === 'true' || currentValue === true) {
+            disabled.add(field.mutually_excludes);
+          }
         }
       }
     }
@@ -419,7 +422,7 @@ function ScrollableFieldGroup({
   groupField: ScenarioField;
   members: ScenarioField[];
   disabledFields: Set<string>;
-  renderField: (field: ScenarioField, isDisabled: boolean) => React.ReactNode;
+  renderField: (field: ScenarioField, isDisabled: boolean) => ReactNode;
 }) {
   const [search, setSearch] = useState('');
 

--- a/src/components/ProviderConfigTab.tsx
+++ b/src/components/ProviderConfigTab.tsx
@@ -37,10 +37,14 @@ export function ProviderConfigTab({ provider, schema, uuid }: ProviderConfigTabP
 
     setIsSubmitting(true);
     try {
-      // Serialize all values to strings as required by API
+      const groupVariables = new Set(
+        schema.fields.filter(f => f.type === 'group').map(f => f.variable)
+      );
       const serializedValues: { [key: string]: string } = {};
       Object.entries(formValues).forEach(([key, value]) => {
-        serializedValues[key] = String(value);
+        if (!groupVariables.has(key)) {
+          serializedValues[key] = String(value);
+        }
       });
 
       await providersApi.submitProviderConfig(uuid, provider.name, serializedValues);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -397,16 +397,29 @@ export const handlers = [
   ),
   http.get(`${BASE}/provider-config/:uuid`, () =>
     HttpResponse.json({
+      uuid: 'mock-provider-config-001',
+      status: 'Completed',
       config_data: {
         aws: {
-          'config-schema': {
-            type: 'object',
-            properties: {
-              region: { type: 'string', description: 'AWS Region', default: 'us-east-1' },
-              access_key: { type: 'string', description: 'AWS Access Key' },
-            },
-          },
-          'config-map': { region: 'us-east-1' },
+          'config-schema': JSON.stringify((() => {
+            const groups = [
+              { name: 'ACM_SECRET_GROUP', short_description: 'ACM/OCM Secret Selection', description: 'Select secrets for direct API connection to managed clusters.', variable: 'ACM_SECRET_GROUP', type: 'group', required: 'false', secret: 'false' },
+              { name: 'ACM_USE_PROXY_GROUP', short_description: 'Cluster Proxy Configuration', description: 'Enable cluster proxy connection for managed clusters. Activating proxy overrides the secret selection.', variable: 'ACM_USE_PROXY_GROUP', type: 'group', required: 'false', secret: 'false' },
+            ];
+            const clusterNames = [
+              'local-cluster', ...Array.from({ length: 30 }, (_, i) => `managed-cluster-${i + 1}`)
+            ];
+            const secrets = clusterNames.map(c => {
+              const varName = c.replace(/-/g, '_').toUpperCase();
+              return { name: `ACM_SECRET_${varName}`, short_description: `Secret for ${c}`, description: `Select the secret for ${c} authentication.`, variable: `ACM_SECRET_${varName}`, default: 'application-manager', separator: ',', allowed_values: 'application-manager,klusterlet-addon-workmgr-log', mutually_excludes: `ACM_USE_PROXY_${varName}`, group: 'ACM_SECRET_GROUP', type: 'enum', required: true, secret: false };
+            });
+            const proxies = clusterNames.map((c, i) => {
+              const varName = c.replace(/-/g, '_').toUpperCase();
+              return { name: `ACM_USE_PROXY_${varName}`, short_description: `Proxy mode for ${c}`, description: `Enable cluster proxy for ${c} instead of direct API access.`, variable: `ACM_USE_PROXY_${varName}`, default: i % 3 === 0 ? 'true' : 'false', separator: ',', allowed_values: 'true,false', mutually_excludes: `ACM_SECRET_${varName}`, group: 'ACM_USE_PROXY_GROUP', type: 'enum', required: false, secret: false };
+            });
+            return [...groups, ...secrets, ...proxies];
+          })()),
+          'config-map': 'krkn-acm-config',
           namespace: 'krkn-operator-system',
         },
       },

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -113,7 +113,7 @@ export interface ScenariosResponse {
 
 // Scenario Detail Types
 
-export type FieldType = 'string' | 'enum' | 'number' | 'file' | 'file_base64' | 'boolean';
+export type FieldType = 'string' | 'enum' | 'number' | 'file' | 'file_base64' | 'boolean' | 'group';
 
 export interface BaseField {
   name: string;
@@ -125,6 +125,8 @@ export interface BaseField {
   required?: boolean;
   type: FieldType;
   secret?: boolean;
+  group?: string;
+  mutually_excludes?: string;
 }
 
 export interface StringField extends BaseField {
@@ -155,7 +157,11 @@ export interface BooleanField extends BaseField {
   type: 'boolean';
 }
 
-export type ScenarioField = StringField | EnumField | NumberField | FileField | FileBase64Field | BooleanField;
+export interface GroupField extends BaseField {
+  type: 'group';
+}
+
+export type ScenarioField = StringField | EnumField | NumberField | FileField | FileBase64Field | BooleanField | GroupField;
 
 export interface ScenarioDetail {
   name: string;

--- a/src/types/provider.ts
+++ b/src/types/provider.ts
@@ -53,7 +53,9 @@ export interface CustomSchemaField {
   separator?: string;
   allowed_values?: string;
   required?: boolean;
-  secret?: boolean; // For password fields
+  secret?: boolean;
+  group?: string;
+  mutually_excludes?: string;
 }
 
 // Provider config data from GET /provider-config/{uuid}

--- a/src/utils/__tests__/schemaParser.test.ts
+++ b/src/utils/__tests__/schemaParser.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { parseCustomSchema } from '../schemaParser';
+
+describe('parseCustomSchema', () => {
+  it('should parse group type fields', () => {
+    const schema = JSON.stringify([
+      { name: 'G1', short_description: 'Group 1', description: 'A group', variable: 'G1', type: 'group', required: 'false', secret: 'false' },
+    ]);
+    const fields = parseCustomSchema(schema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].type).toBe('group');
+    expect(fields[0].short_description).toBe('Group 1');
+  });
+
+  it('should preserve group and mutually_excludes on fields', () => {
+    const schema = JSON.stringify([
+      { name: 'G1', short_description: 'Group', description: 'Grp', variable: 'G1', type: 'group', required: false, secret: false },
+      { name: 'F1', short_description: 'Field 1', description: 'Desc', variable: 'F1', type: 'enum', default: 'a', separator: ',', allowed_values: 'a,b', group: 'G1', mutually_excludes: 'F2', required: true, secret: false },
+    ]);
+    const fields = parseCustomSchema(schema);
+    expect(fields[1].group).toBe('G1');
+    expect(fields[1].mutually_excludes).toBe('F2');
+  });
+
+  it('should normalize string "false" to boolean false for required', () => {
+    const schema = JSON.stringify([
+      { name: 'F1', description: 'Desc', variable: 'F1', type: 'string', required: 'false', secret: 'false' },
+    ]);
+    const fields = parseCustomSchema(schema);
+    expect(fields[0].required).toBe(false);
+  });
+
+  it('should normalize string "true" to boolean true for required', () => {
+    const schema = JSON.stringify([
+      { name: 'F1', description: 'Desc', variable: 'F1', type: 'string', required: 'true', secret: 'false' },
+    ]);
+    const fields = parseCustomSchema(schema);
+    expect(fields[0].required).toBe(true);
+  });
+
+  it('should normalize string "false" to boolean false for secret', () => {
+    const schema = JSON.stringify([
+      { name: 'F1', description: 'Desc', variable: 'F1', type: 'string', required: false, secret: 'false' },
+    ]);
+    const fields = parseCustomSchema(schema);
+    expect(fields[0].secret).toBe(false);
+  });
+
+  it('should normalize string "true" to boolean true for secret', () => {
+    const schema = JSON.stringify([
+      { name: 'F1', description: 'Desc', variable: 'F1', type: 'string', required: false, secret: 'true' },
+    ]);
+    const fields = parseCustomSchema(schema);
+    expect(fields[0].secret).toBe(true);
+  });
+
+  it('should preserve boolean true/false without corruption', () => {
+    const schema = JSON.stringify([
+      { name: 'F1', description: 'Desc', variable: 'F1', type: 'string', required: true, secret: false },
+    ]);
+    const fields = parseCustomSchema(schema);
+    expect(fields[0].required).toBe(true);
+    expect(fields[0].secret).toBe(false);
+  });
+
+  it('should parse schemas without group/mutually_excludes (backward compat)', () => {
+    const schema = JSON.stringify([
+      { name: 'F1', short_description: 'Field 1', description: 'Desc', variable: 'F1', type: 'string', required: true },
+    ]);
+    const fields = parseCustomSchema(schema);
+    expect(fields).toHaveLength(1);
+    expect(fields[0].group).toBeUndefined();
+    expect(fields[0].mutually_excludes).toBeUndefined();
+  });
+});

--- a/src/utils/schemaParser.ts
+++ b/src/utils/schemaParser.ts
@@ -113,6 +113,8 @@ function mapCustomSchemaType(type: number | string): FieldType {
         return 'enum';
       case 'boolean':
         return 'boolean';
+      case 'group':
+        return 'group';
       default:
         return 'string';
     }
@@ -157,6 +159,9 @@ export function parseCustomSchema(schemaString: string): ScenarioField[] {
         type: fieldType,
         default: customField.default,
         required: customField.required,
+        secret: customField.secret,
+        group: customField.group,
+        mutually_excludes: customField.mutually_excludes,
       } as ScenarioField;
 
       // Add enum-specific fields

--- a/src/utils/schemaParser.ts
+++ b/src/utils/schemaParser.ts
@@ -93,6 +93,10 @@ export function parseJsonSchema(schemaString: string): ScenarioField[] {
   }
 }
 
+function toBool(value: unknown): boolean {
+  return value === true || value === 'true';
+}
+
 /**
  * Convert custom schema field type to ScenarioField type
  * Supports both numeric and string types:
@@ -158,8 +162,8 @@ export function parseCustomSchema(schemaString: string): ScenarioField[] {
         variable: customField.variable,
         type: fieldType,
         default: customField.default,
-        required: customField.required,
-        secret: customField.secret,
+        required: toBool(customField.required),
+        secret: toBool(customField.secret),
         group: customField.group,
         mutually_excludes: customField.mutually_excludes,
       } as ScenarioField;


### PR DESCRIPTION

Add support for `type: "group"` fields that organize provider config into visual sections with titled headers, scrollable field lists, and search filtering. Implement `mutually_excludes` logic so boolean-like enum fields disable their counterpart when set to true. Fix existing bug where `secret` was not preserved during custom schema parsing.