### PR TITLE
fix(scenario): include fileReferences in run request

### DIFF
--- a/src/components/ScenarioDetail.test.tsx
+++ b/src/components/ScenarioDetail.test.tsx
@@ -832,6 +832,214 @@ describe('ScenarioDetail', () => {
     });
   });
 
-  // NOTE: FileSelector integration tests are in FileSelector.test.tsx
-  // Warning system for pending file input is tested at the component level
+  describe('File References in Run Request', () => {
+    const mockCreateResponse: CreateScenarioRunResponse = {
+      scenarioRunName: 'test-run-456',
+      targetClusters: { 'krkn-operator': ['cluster1'] },
+      totalTargets: 1,
+    };
+
+    const mockStatusResponse: ScenarioRunStatusResponse = {
+      scenarioRunName: 'test-run-456',
+      phase: 'Running',
+      totalTargets: 1,
+      successfulJobs: 0,
+      failedJobs: 0,
+      runningJobs: 1,
+      clusterJobs: [],
+    };
+
+    const mockActiveRuns: ActiveRunsResponse = {
+      totalActiveRuns: 0,
+      totalClusters: 0,
+      clusterRuns: {},
+    };
+
+    it('should include fileReferences in run request when files are added', async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(operatorApi.getAvailableFiles).mockResolvedValue({
+        files: [
+          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config' },
+        ],
+      });
+      vi.mocked(operatorApi.runScenario).mockResolvedValueOnce(mockCreateResponse);
+      vi.mocked(operatorApi.getScenarioRunStatus).mockResolvedValueOnce(mockStatusResponse);
+      vi.mocked(operatorApi.getActiveRuns).mockResolvedValueOnce(mockActiveRuns);
+
+      renderWithContext({
+        scenarioFormValues: { NAMESPACE: 'default' },
+      });
+
+      // Wait for FileSelector to load available files
+      await waitFor(() => {
+        expect(operatorApi.getAvailableFiles).toHaveBeenCalled();
+      });
+
+      // Open the file select dropdown and choose a file
+      const fileToggle = await screen.findByText('Select a file');
+      await user.click(fileToggle);
+      const fileOption = await screen.findByText('metrics.yaml');
+      await user.click(fileOption);
+
+      // Type mount path
+      const mountInput = screen.getByPlaceholderText('/path/to/mount/file.yaml');
+      await user.type(mountInput, '/etc/krkn/metrics.yaml');
+
+      // Click Add
+      await user.click(screen.getByRole('button', { name: /Add/i }));
+
+      // Preview
+      await user.click(screen.getByRole('button', { name: /Preview Configuration/i }));
+      expect(screen.getByText('Configuration Preview')).toBeInTheDocument();
+
+      // Run
+      await user.click(screen.getByRole('button', { name: /Run Scenarios/i }));
+
+      await waitFor(() => {
+        expect(operatorApi.runScenario).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fileReferences: [{ fileId: 'file-1', mountPath: '/etc/krkn/metrics.yaml' }],
+          })
+        );
+      });
+    });
+
+    it('should not include fileReferences when no files are added', async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(operatorApi.runScenario).mockResolvedValueOnce(mockCreateResponse);
+      vi.mocked(operatorApi.getScenarioRunStatus).mockResolvedValueOnce(mockStatusResponse);
+      vi.mocked(operatorApi.getActiveRuns).mockResolvedValueOnce(mockActiveRuns);
+
+      renderWithContext({
+        scenarioFormValues: { NAMESPACE: 'default' },
+      });
+
+      await user.click(screen.getByRole('button', { name: /Preview Configuration/i }));
+      await user.click(screen.getByRole('button', { name: /Run Scenarios/i }));
+
+      await waitFor(() => {
+        expect(operatorApi.runScenario).toHaveBeenCalledWith(
+          expect.objectContaining({
+            fileReferences: undefined,
+          })
+        );
+      });
+    });
+  });
+
+  describe('Pending File Warning Modal', () => {
+    it('should show modal when preview clicked with pending file input', async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(operatorApi.getAvailableFiles).mockResolvedValue({
+        files: [
+          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config' },
+        ],
+      });
+
+      renderWithContext({
+        scenarioFormValues: { NAMESPACE: 'default' },
+      });
+
+      await waitFor(() => {
+        expect(operatorApi.getAvailableFiles).toHaveBeenCalled();
+      });
+
+      // Select a file but do NOT click Add
+      const fileToggle = await screen.findByText('Select a file');
+      await user.click(fileToggle);
+      const fileOption = await screen.findByText('metrics.yaml');
+      await user.click(fileOption);
+
+      // Click Preview — modal should appear
+      await user.click(screen.getByRole('button', { name: /Preview Configuration/i }));
+
+      expect(screen.getByText('Pending file not added')).toBeInTheDocument();
+      expect(screen.getByText(/haven't clicked/)).toBeInTheDocument();
+    });
+
+    it('should show modal when only mount path is typed without selecting a file', async () => {
+      const user = userEvent.setup();
+
+      renderWithContext({
+        scenarioFormValues: { NAMESPACE: 'default' },
+      });
+
+      // Type only mount path, no file selected
+      const mountInput = screen.getByPlaceholderText('/path/to/mount/file.yaml');
+      await user.type(mountInput, '/etc/krkn/config.yaml');
+
+      // Click Preview — modal should appear
+      await user.click(screen.getByRole('button', { name: /Preview Configuration/i }));
+
+      expect(screen.getByText('Pending file not added')).toBeInTheDocument();
+    });
+
+    it('should return to form when "Go back" is clicked', async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(operatorApi.getAvailableFiles).mockResolvedValue({
+        files: [
+          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config' },
+        ],
+      });
+
+      renderWithContext({
+        scenarioFormValues: { NAMESPACE: 'default' },
+      });
+
+      await waitFor(() => {
+        expect(operatorApi.getAvailableFiles).toHaveBeenCalled();
+      });
+
+      const fileToggle = await screen.findByText('Select a file');
+      await user.click(fileToggle);
+      await user.click(await screen.findByText('metrics.yaml'));
+
+      await user.click(screen.getByRole('button', { name: /Preview Configuration/i }));
+      expect(screen.getByText('Pending file not added')).toBeInTheDocument();
+
+      // Click "Go back"
+      await user.click(screen.getByRole('button', { name: /Go back/i }));
+
+      // Modal should close, preview should NOT appear
+      expect(screen.queryByText('Pending file not added')).not.toBeInTheDocument();
+      expect(screen.queryByText('Configuration Preview')).not.toBeInTheDocument();
+      expect(screen.getByText('Required Parameters')).toBeInTheDocument();
+    });
+
+    it('should proceed to preview when "Continue without adding" is clicked', async () => {
+      const user = userEvent.setup();
+
+      vi.mocked(operatorApi.getAvailableFiles).mockResolvedValue({
+        files: [
+          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config' },
+        ],
+      });
+
+      renderWithContext({
+        scenarioFormValues: { NAMESPACE: 'default' },
+      });
+
+      await waitFor(() => {
+        expect(operatorApi.getAvailableFiles).toHaveBeenCalled();
+      });
+
+      const fileToggle = await screen.findByText('Select a file');
+      await user.click(fileToggle);
+      await user.click(await screen.findByText('metrics.yaml'));
+
+      await user.click(screen.getByRole('button', { name: /Preview Configuration/i }));
+      expect(screen.getByText('Pending file not added')).toBeInTheDocument();
+
+      // Click "Continue without adding"
+      await user.click(screen.getByRole('button', { name: /Continue without adding/i }));
+
+      // Should proceed to preview
+      expect(screen.queryByText('Pending file not added')).not.toBeInTheDocument();
+      expect(screen.getByText('Configuration Preview')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/ScenarioDetail.test.tsx
+++ b/src/components/ScenarioDetail.test.tsx
@@ -860,7 +860,7 @@ describe('ScenarioDetail', () => {
 
       vi.mocked(operatorApi.getAvailableFiles).mockResolvedValue({
         files: [
-          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config' },
+          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config', availableToAll: true },
         ],
       });
       vi.mocked(operatorApi.runScenario).mockResolvedValueOnce(mockCreateResponse);
@@ -935,7 +935,7 @@ describe('ScenarioDetail', () => {
 
       vi.mocked(operatorApi.getAvailableFiles).mockResolvedValue({
         files: [
-          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config' },
+          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config', availableToAll: true },
         ],
       });
 
@@ -982,7 +982,7 @@ describe('ScenarioDetail', () => {
 
       vi.mocked(operatorApi.getAvailableFiles).mockResolvedValue({
         files: [
-          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config' },
+          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config', availableToAll: true },
         ],
       });
 
@@ -1015,7 +1015,7 @@ describe('ScenarioDetail', () => {
 
       vi.mocked(operatorApi.getAvailableFiles).mockResolvedValue({
         files: [
-          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config' },
+          { fileId: 'file-1', fileName: 'metrics.yaml', description: 'Metrics config', availableToAll: true },
         ],
       });
 

--- a/src/components/ScenarioDetail.tsx
+++ b/src/components/ScenarioDetail.tsx
@@ -8,7 +8,10 @@ import {
   Alert,
   Spinner,
   Checkbox,
+  Modal,
+  ModalVariant,
 } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { Table, Thead, Tbody, Tr, Th, Td } from '@patternfly/react-table';
 import { useAppContext } from '../context/AppContext';
 import { useNotifications } from '../hooks';
@@ -51,7 +54,6 @@ export function ScenarioDetail({ scenarioName, registryConfig }: ScenarioDetailP
   const [showOptionalFields, setShowOptionalFields] = useState(false);
   const [showGlobalParameters, setShowGlobalParameters] = useState(false);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
-  const [validationWarnings, setValidationWarnings] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [conflictWarning, setConflictWarning] = useState<{
     clusterName: string;
@@ -61,7 +63,7 @@ export function ScenarioDetail({ scenarioName, registryConfig }: ScenarioDetailP
   const [fileReferences, setFileReferences] = useState<import('../types/api').FileReference[]>([]);
   const [availableFiles, setAvailableFiles] = useState<import('../types/api').FileInfo[]>([]);
   const [hasPendingFileInput, setHasPendingFileInput] = useState(false);
-  const [pendingFileWarningShown, setPendingFileWarningShown] = useState(false);
+  const [isPendingFileModalOpen, setIsPendingFileModalOpen] = useState(false);
 
   // Load available files for file reference mapping
   useEffect(() => {
@@ -77,13 +79,6 @@ export function ScenarioDetail({ scenarioName, registryConfig }: ScenarioDetailP
     loadFiles();
   }, []);
 
-  // Reset warning when pending input is cleared
-  useEffect(() => {
-    if (!hasPendingFileInput && pendingFileWarningShown) {
-      setPendingFileWarningShown(false);
-      setValidationWarnings([]);
-    }
-  }, [hasPendingFileInput, pendingFileWarningShown]);
 
   useEffect(() => {
     const fetchScenarioDetail = async () => {
@@ -191,17 +186,15 @@ export function ScenarioDetail({ scenarioName, registryConfig }: ScenarioDetailP
   };
 
   const handlePreview = () => {
-    // Check for pending file input BEFORE validation
-    if (hasPendingFileInput && !pendingFileWarningShown) {
-      setValidationWarnings([
-        'You have unsaved changes in the Managed Files section. Click "Add" to include the file, or clear the selection to proceed without it.',
-      ]);
-      setPendingFileWarningShown(true);
+    if (hasPendingFileInput) {
+      setIsPendingFileModalOpen(true);
       return;
     }
+    proceedToPreview();
+  };
 
+  const proceedToPreview = () => {
     if (validateForm()) {
-      setValidationWarnings([]); // Clear warnings when proceeding
       setShowPreview(true);
     }
   };
@@ -363,6 +356,7 @@ export function ScenarioDetail({ scenarioName, registryConfig }: ScenarioDetailP
         kubeconfigPath: '/home/krkn/.kube/config',
         environment,
         files: files.length > 0 ? files : undefined,
+        fileReferences: fileReferences.length > 0 ? fileReferences : undefined,
         registryName: registryConfig?.registryName,
       };
 
@@ -460,20 +454,40 @@ export function ScenarioDetail({ scenarioName, registryConfig }: ScenarioDetailP
         </Alert>
       )}
 
-      {/* Validation Warnings */}
-      {validationWarnings.length > 0 && (
-        <Alert
-          variant="warning"
-          title="Warning"
-          style={{ marginBottom: '1.5rem' }}
-        >
-          <ul>
-            {validationWarnings.map((warning, index) => (
-              <li key={index}>{warning}</li>
-            ))}
-          </ul>
-        </Alert>
-      )}
+      {/* Pending File Warning Modal */}
+      <Modal
+        variant={ModalVariant.small}
+        title="Pending file not added"
+        titleIconVariant={ExclamationTriangleIcon}
+        isOpen={isPendingFileModalOpen}
+        onClose={() => setIsPendingFileModalOpen(false)}
+        actions={[
+          <Button
+            key="continue"
+            variant="primary"
+            onClick={() => {
+              setIsPendingFileModalOpen(false);
+              proceedToPreview();
+            }}
+          >
+            Continue without adding
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            onClick={() => setIsPendingFileModalOpen(false)}
+          >
+            Go back
+          </Button>,
+        ]}
+      >
+        <p>
+          You have selected a file in the Managed Files section but you haven&apos;t clicked
+          the <strong>&laquo;Add&raquo;</strong> button yet. The file will <strong>not</strong> be
+          included in the run unless you go back and click <strong>&laquo;Add&raquo;</strong> to
+          confirm it.
+        </p>
+      </Modal>
 
       {!showPreview ? (
         <>
@@ -499,12 +513,7 @@ export function ScenarioDetail({ scenarioName, registryConfig }: ScenarioDetailP
               </div>
               <FileSelector
                 value={fileReferences}
-                onChange={(refs) => {
-                  setFileReferences(refs);
-                  // Reset warning when user adds/removes files
-                  setPendingFileWarningShown(false);
-                  setValidationWarnings([]);
-                }}
+                onChange={setFileReferences}
                 onPendingChange={setHasPendingFileInput}
               />
             </CardBody>

--- a/src/components/Studio/SaveWorkflowConfirmModal.tsx
+++ b/src/components/Studio/SaveWorkflowConfirmModal.tsx
@@ -17,7 +17,7 @@ interface SaveWorkflowConfirmModalProps {
 /**
  * Confirmation modal for updating an already-saved workflow on the cluster.
  *
- * Shown when the user clicks "Save to Cluster" on a workflow that already has
+ * Shown when the user clicks "Save Workflow" on a workflow that already has
  * a cluster file. Calls `saveWorkflowToCluster` from StudioContext, which
  * persists the current canvas state and updates the saved snapshot.
  *

--- a/src/components/Studio/StudioToolbar.test.tsx
+++ b/src/components/Studio/StudioToolbar.test.tsx
@@ -58,7 +58,7 @@ describe('StudioToolbar', () => {
   });
 
   describe('Save button text', () => {
-    it('shows "Save to Cluster" when no savedFile', () => {
+    it('shows "Save Workflow" when no savedFile', () => {
       vi.mocked(useStudioContext).mockReturnValue(
         buildMockContext({
           workflow: {
@@ -71,10 +71,10 @@ describe('StudioToolbar', () => {
 
       render(<StudioToolbar onRunWorkflow={mockOnRunWorkflow} />);
 
-      expect(screen.getByText('Save to Cluster')).toBeInTheDocument();
+      expect(screen.getByText('Save Workflow')).toBeInTheDocument();
     });
 
-    it('shows "Save to Cluster" when savedFile exists but isDirty is false', () => {
+    it('shows "Save Workflow" when savedFile exists but isDirty is false', () => {
       vi.mocked(useStudioContext).mockReturnValue(
         buildMockContext({
           workflow: {
@@ -94,7 +94,7 @@ describe('StudioToolbar', () => {
 
       render(<StudioToolbar onRunWorkflow={mockOnRunWorkflow} />);
 
-      expect(screen.getByText('Save to Cluster')).toBeInTheDocument();
+      expect(screen.getByText('Save Workflow')).toBeInTheDocument();
     });
 
     it('shows "Update Workflow" when savedFile exists and isDirty is true', () => {
@@ -302,7 +302,7 @@ describe('StudioToolbar', () => {
 
       render(<StudioToolbar onRunWorkflow={mockOnRunWorkflow} />);
 
-      const saveButton = screen.getByText('Save to Cluster').closest('button')!;
+      const saveButton = screen.getByText('Save Workflow').closest('button')!;
       expect(saveButton).toBeDisabled();
     });
 
@@ -311,7 +311,7 @@ describe('StudioToolbar', () => {
 
       render(<StudioToolbar onRunWorkflow={mockOnRunWorkflow} />);
 
-      const saveButton = screen.getByText('Save to Cluster').closest('button')!;
+      const saveButton = screen.getByText('Save Workflow').closest('button')!;
       expect(saveButton).toBeDisabled();
     });
   });
@@ -371,7 +371,7 @@ describe('StudioToolbar', () => {
 
       render(<StudioToolbar onRunWorkflow={mockOnRunWorkflow} />);
 
-      await user.click(screen.getByText('Save to Cluster'));
+      await user.click(screen.getByText('Save Workflow'));
 
       expect(screen.getByTestId('save-workflow-modal')).toBeInTheDocument();
     });

--- a/src/components/Studio/StudioToolbar.tsx
+++ b/src/components/Studio/StudioToolbar.tsx
@@ -24,12 +24,12 @@ interface StudioToolbarProps {
 /**
  * Toolbar for Chaos Studio canvas actions.
  *
- * Provides buttons for: Add Scenario, Run Workflow, Export JSON, Save to Cluster,
+ * Provides buttons for: Add Scenario, Run Workflow, Export JSON, Save Workflow,
  * and Clear All. Includes pre-run validation (blocks unconfigured nodes) and an
  * unsaved-changes guard with Save & Run / Run without saving options.
  *
  * The save button label changes dynamically:
- * - "Save to Cluster" for new workflows or clean saved workflows.
+ * - "Save Workflow" for new workflows or clean saved workflows.
  * - "Update Workflow" when a saved workflow has pending changes.
  *
  * @example
@@ -170,7 +170,7 @@ export function StudioToolbar({ onRunWorkflow }: StudioToolbarProps) {
               onClick={handleSave}
               isDisabled={workflow.nodes.length === 0 || isEditingDetails}
             >
-              {savedFile && isDirty ? 'Update Workflow' : 'Save to Cluster'}
+              {savedFile && isDirty ? 'Update Workflow' : 'Save Workflow'}
             </Button>
           </ToolbarItem>
 


### PR DESCRIPTION


fileReferences were collected by FileSelector but never included in the ScenarioRunRequest body, so mounted files were silently dropped from runs.

The old pending-file warning (an Alert at the top of the page that could be bypassed on second click) is replaced with a blocking Modal that clearly tells the user they need to click "Add" to include the file.