### PR TITLE
Add needs-rebase workflow

### DIFF
--- a/.github/workflows/needs-rebase.yml
+++ b/.github/workflows/needs-rebase.yml
@@ -1,0 +1,16 @@
+name: Needs Rebase
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  rebase:
+    uses: krkn-chaos/actions/.github/workflows/needs-rebase.yml@d17d7433f988dc95a7ae2b15b3505b1f256dc1f6 # main


### PR DESCRIPTION
## Summary
- Adds the `needs-rebase` workflow from [krkn-chaos/krkn](https://github.com/krkn-chaos/krkn/blob/main/.github/workflows/needs-rebase.yml)
- Labels PRs that need to be rebased on top of main

## Test plan
- [ ] Verify workflow triggers on PR open/sync/reopen and pushes to main
- [ ] Confirm label is applied to PRs with merge conflicts