### PR TITLE
Blocking certain scenarios without cloud configuraiton

### DIFF
--- a/src/components/ScenariosList.tsx
+++ b/src/components/ScenariosList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { isScenarioBlocked } from '../utils/blockedScenarios';
 import {
   Card,
   CardBody,
@@ -24,6 +25,7 @@ import {
   MenuToggle,
   MenuToggleElement,
   SearchInput,
+  Tooltip,
 } from '@patternfly/react-core';
 import { FileCodeIcon, SortAmountDownIcon, CopyIcon } from '@patternfly/react-icons';
 import { useAppContext } from '../context/AppContext';
@@ -281,12 +283,29 @@ export function ScenariosList() {
                         </div>
                       </DataListCell>,
                       <DataListCell key="actions" width={1}>
-                        <Button
-                          variant="primary"
-                          onClick={() => handleConfigureScenario(scenario.name)}
-                        >
-                          Configure
-                        </Button>
+                        {isScenarioBlocked(scenario.name) ? (
+                          <Tooltip
+                            content="Not configured yet — cloud provider credentials support is coming in the next release (krkn-operator#43)."
+                          >
+                            <span style={{ display: 'inline-block', cursor: 'not-allowed' }}>
+                              <Button
+                                variant="primary"
+                                isDisabled
+                                aria-disabled="true"
+                                style={{ pointerEvents: 'none' }}
+                              >
+                                Configure
+                              </Button>
+                            </span>
+                          </Tooltip>
+                        ) : (
+                          <Button
+                            variant="primary"
+                            onClick={() => handleConfigureScenario(scenario.name)}
+                          >
+                            Configure
+                          </Button>
+                        )}
                       </DataListCell>,
                     ]}
                   />

--- a/src/components/Studio/ScenariosListStep.tsx
+++ b/src/components/Studio/ScenariosListStep.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState } from 'react';
+import { isScenarioBlocked } from '../../utils/blockedScenarios';
 import {
   DataList,
   DataListItem,
@@ -20,6 +21,7 @@ import {
   EmptyStateIcon,
   EmptyStateBody,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import { FileCodeIcon } from '@patternfly/react-icons';
 import type { ScenarioTag } from '../../types/api';
@@ -61,9 +63,10 @@ export function ScenariosListStep({
   };
 
   // Filter scenarios based on search
-  const filteredScenarios = scenarios.filter((scenario) =>
-    scenario.name.toLowerCase().includes(searchValue.toLowerCase())
-  );
+  const filteredScenarios = scenarios
+    .filter((scenario) =>
+      scenario.name.toLowerCase().includes(searchValue.toLowerCase())
+    );
 
   // Sort by name
   const sortedScenarios = [...filteredScenarios].sort((a, b) =>
@@ -101,52 +104,69 @@ export function ScenariosListStep({
         <DataList
           aria-label="Scenarios list"
           selectedDataListItemId={selectedScenario || undefined}
-          onSelectDataListItem={(_event, id) => onSelectScenario(id)}
+          onSelectDataListItem={(_event, id) => {
+            if (!isScenarioBlocked(id)) onSelectScenario(id);
+          }}
           isCompact
         >
-          {sortedScenarios.map((scenario) => (
-            <DataListItem
-              key={scenario.name}
-              id={scenario.name}
-              style={{
-                cursor: 'pointer',
-                backgroundColor:
-                  selectedScenario === scenario.name
-                    ? 'var(--pf-v5-global--BackgroundColor--200)'
-                    : undefined,
-              }}
-            >
-              <DataListItemRow>
-                <DataListItemCells
-                  dataListCells={[
-                    <DataListCell key="name" width={3}>
-                      <div>
-                        <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>
-                          {scenario.name}
+          {sortedScenarios.map((scenario) => {
+            const blocked = isScenarioBlocked(scenario.name);
+            const row = (
+              <DataListItem
+                key={scenario.name}
+                id={scenario.name}
+                style={{
+                  cursor: blocked ? 'not-allowed' : 'pointer',
+                  opacity: blocked ? 0.5 : 1,
+                  backgroundColor:
+                    !blocked && selectedScenario === scenario.name
+                      ? 'var(--pf-v5-global--BackgroundColor--200)'
+                      : undefined,
+                  pointerEvents: blocked ? 'none' : undefined,
+                }}
+                aria-disabled={blocked}
+              >
+                <DataListItemRow>
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell key="name" width={3}>
+                        <div>
+                          <div style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>
+                            {scenario.name}
+                          </div>
+                          <div style={{ fontSize: 'var(--pf-v5-global--FontSize--sm)', color: 'var(--pf-v5-global--Color--200)' }}>
+                            Size: {formatBytes(scenario.size)}
+                          </div>
                         </div>
-                        <div style={{ fontSize: 'var(--pf-v5-global--FontSize--sm)', color: 'var(--pf-v5-global--Color--200)' }}>
-                          Size: {formatBytes(scenario.size)}
-                        </div>
-                      </div>
-                    </DataListCell>,
-                    <DataListCell key="digest" width={2}>
-                      {scenario.digest && (
-                        <div
-                          style={{
-                            fontSize: 'var(--pf-v5-global--FontSize--sm)',
-                            fontFamily: 'var(--pf-v5-global--FontFamily--monospace)',
-                            color: 'var(--pf-v5-global--Color--200)',
-                          }}
-                        >
-                          {scenario.digest.substring(0, 19)}...
-                        </div>
-                      )}
-                    </DataListCell>,
-                  ]}
-                />
-              </DataListItemRow>
-            </DataListItem>
-          ))}
+                      </DataListCell>,
+                      <DataListCell key="digest" width={2}>
+                        {scenario.digest && (
+                          <div
+                            style={{
+                              fontSize: 'var(--pf-v5-global--FontSize--sm)',
+                              fontFamily: 'var(--pf-v5-global--FontFamily--monospace)',
+                              color: 'var(--pf-v5-global--Color--200)',
+                            }}
+                          >
+                            {scenario.digest.substring(0, 19)}...
+                          </div>
+                        )}
+                      </DataListCell>,
+                    ]}
+                  />
+                </DataListItemRow>
+              </DataListItem>
+            );
+
+            return blocked ? (
+              <Tooltip
+                key={scenario.name}
+                content="Cloud provider credentials are required for this scenario. Configuration is not yet available — see krkn-operator issue #43."
+              >
+                <span style={{ display: 'block' }}>{row}</span>
+              </Tooltip>
+            ) : row;
+          })}
         </DataList>
       )}
     </div>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -377,11 +377,12 @@ const mockTargets = [
 // ─── SCENARIOS (ScenarioTag) ───
 
 const mockScenarios = [
-  { name: 'pod-disruption' },
-  { name: 'node-cpu-hog' },
-  { name: 'network-chaos' },
-  { name: 'container-kill' },
-  { name: 'time-skew' },
+  { name: 'pod-disruption', description: 'Disrupts pods in target namespaces' },
+  { name: 'node-cpu-hog', description: 'Stresses CPU on target nodes' },
+  { name: 'network-chaos', description: 'Introduces network latency and packet loss' },
+  { name: 'container-kill', description: 'Kills containers in target pods' },
+  { name: 'time-skew', description: 'Skews system time on target nodes' },
+  { name: 'node-scenarios', description: 'Node-level chaos scenarios requiring cloud provider credentials' },
 ];
 
 // ─── FILES (FileInfo for listings) ───

--- a/src/utils/blockedScenarios.test.ts
+++ b/src/utils/blockedScenarios.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { isScenarioBlocked } from './blockedScenarios';
+
+describe('isScenarioBlocked', () => {
+  it.each([
+    ['node-scenarios prefix blocks node-scenarios-bm', 'node-scenarios-bm', true],
+    ['node-scenarios prefix blocks node-scenarios', 'node-scenarios', true],
+    ['exact match blocks zone-outages', 'zone-outages', true],
+    ['exact match blocks power-outages', 'power-outages', true],
+    ['node- alone is now allowed', 'node-cpu-hog', false],
+    ['node-drain is now allowed', 'node-drain', false],
+    ["bare 'node' is not blocked", 'node', false],
+    ['pod-disruption is allowed', 'pod-disruption', false],
+    ['network-chaos is allowed', 'network-chaos', false],
+    ['container-kill is allowed', 'container-kill', false],
+  ])('%s', (_label, scenario, expected) => {
+    expect(isScenarioBlocked(scenario)).toBe(expected);
+  });
+});

--- a/src/utils/blockedScenarios.ts
+++ b/src/utils/blockedScenarios.ts
@@ -1,0 +1,7 @@
+const BLOCKED_PREFIXES = ['node-scenarios'];
+const BLOCKED_EXACT = new Set(['zone-outages', 'power-outages']);
+
+export function isScenarioBlocked(name: string): boolean {
+  if (BLOCKED_EXACT.has(name)) return true;
+  return BLOCKED_PREFIXES.some((prefix) => name.startsWith(prefix));
+}


### PR DESCRIPTION
This pr removes the ability to run scenarios that are not yet set up cloud configurations for them to run. I greying/disallowing the configure button for those items and linking them to the future work item 

https://github.com/krkn-chaos/krkn-operator/pull/61

<img width="1920" height="1080" alt="Screenshot 2026-08-05 at 9 12 10 AM" src="https://github.com/user-attachments/assets/ce113ee3-efda-4339-b1ef-5a490a9eea7f" />


Docs PR: https://github.com/krkn-chaos/website/pull/581
