### PR TITLE
Use toggle switches for enable/disable fields

### DIFF
--- a/src/components/DynamicFormBuilder.test.tsx
+++ b/src/components/DynamicFormBuilder.test.tsx
@@ -25,6 +25,18 @@ function makeStringField(variable: string, shortDesc: string): ScenarioField {
   return { name: variable, short_description: shortDesc, description: `Desc for ${variable}`, variable, type: 'string', required: false, secret: false } as ScenarioField;
 }
 
+function makeBooleanField(
+  variable: string,
+  shortDesc: string,
+  opts: { mutually_excludes?: string; default?: string } = {},
+): ScenarioField {
+  return {
+    name: variable, short_description: shortDesc, description: `Desc for ${variable}`,
+    variable, type: 'boolean', required: false, secret: false,
+    mutually_excludes: opts.mutually_excludes, default: opts.default,
+  } as ScenarioField;
+}
+
 describe('DynamicFormBuilder', () => {
   describe('group rendering', () => {
     it('should render group headers with title and description', () => {
@@ -166,7 +178,7 @@ describe('DynamicFormBuilder', () => {
       const values: ScenarioFormValues = { PROXY: 'false', SECRET: 'workmgr' };
       render(<DynamicFormBuilder fields={fields} values={values} onChange={onChange} />);
 
-      const proxyToggle = screen.getByRole('checkbox', { name: /Proxy/i });
+      const proxyToggle = screen.getByRole('checkbox', { name: /False/i });
       await user.click(proxyToggle);
 
       const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
@@ -180,7 +192,61 @@ describe('DynamicFormBuilder', () => {
       ];
       render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
 
-      expect(screen.getByRole('checkbox', { name: /My Toggle/i })).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: /False/i })).toBeInTheDocument();
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('boolean type mutually_excludes', () => {
+    it('should disable excluded field when boolean toggle is on', () => {
+      const fields: ScenarioField[] = [
+        makeBooleanField('ENABLE', 'Enable Feature', { mutually_excludes: 'TARGET' }),
+        makeEnumField('TARGET', 'Target Setting'),
+      ];
+      const values: ScenarioFormValues = { ENABLE: true, TARGET: 'a' };
+      render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
+
+      const targetSelect = screen.getByRole('combobox', { name: /Target Setting/i });
+      expect(targetSelect).toBeDisabled();
+    });
+
+    it('should not disable excluded field when boolean toggle is off', () => {
+      const fields: ScenarioField[] = [
+        makeBooleanField('ENABLE', 'Enable Feature', { mutually_excludes: 'TARGET' }),
+        makeEnumField('TARGET', 'Target Setting'),
+      ];
+      const values: ScenarioFormValues = { ENABLE: false, TARGET: 'a' };
+      render(<DynamicFormBuilder fields={fields} values={values} onChange={vi.fn()} />);
+
+      const targetSelect = screen.getByRole('combobox', { name: /Target Setting/i });
+      expect(targetSelect).not.toBeDisabled();
+    });
+
+    it('should reset excluded field value when boolean toggle is turned on', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      const fields: ScenarioField[] = [
+        makeBooleanField('ENABLE', 'Enable Feature', { mutually_excludes: 'TARGET', default: 'false' }),
+        makeEnumField('TARGET', 'Target Setting', { allowed_values: 'a,b', default: 'a' }),
+      ];
+      const values: ScenarioFormValues = { ENABLE: false, TARGET: 'b' };
+      render(<DynamicFormBuilder fields={fields} values={values} onChange={onChange} />);
+
+      const toggle = screen.getByRole('checkbox', { name: /False/i });
+      await user.click(toggle);
+
+      const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1][0];
+      expect(lastCall.ENABLE).toBe(true);
+      expect(lastCall.TARGET).toBe('a');
+    });
+
+    it('should render boolean field as a Switch toggle', () => {
+      const fields: ScenarioField[] = [
+        makeBooleanField('FLAG', 'My Flag'),
+      ];
+      render(<DynamicFormBuilder fields={fields} values={{}} onChange={vi.fn()} />);
+
+      expect(screen.getByRole('checkbox', { name: /False/i })).toBeInTheDocument();
       expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
     });
   });

--- a/src/components/DynamicFormBuilder.tsx
+++ b/src/components/DynamicFormBuilder.tsx
@@ -6,7 +6,6 @@ import {
   TextInput,
   FormSelect,
   FormSelectOption,
-  Checkbox,
   FileUpload,
   FormHelperText,
   HelperText,
@@ -42,6 +41,12 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
           if (currentValue === 'true' || currentValue === true) {
             disabled.add(field.mutually_excludes);
           }
+        }
+      }
+      if (field.mutually_excludes && field.type === 'boolean') {
+        const currentValue = values[field.variable] ?? field.default ?? '';
+        if (currentValue === 'true' || currentValue === true) {
+          disabled.add(field.mutually_excludes);
         }
       }
     }
@@ -254,10 +259,11 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
 
         if (isBooleanEnum) {
           return (
-            <FormGroup key={field.variable} fieldId={field.variable}>
+            <FormGroup key={field.variable} label={field.short_description} fieldId={field.variable}>
               <Switch
                 id={field.variable}
-                label={field.short_description}
+                label="True"
+                labelOff="False"
                 isChecked={value === 'true' || value === true}
                 onChange={(_event, checked) => handleChange(field.variable, checked ? 'true' : 'false')}
                 isDisabled={isFieldDisabled}
@@ -314,15 +320,22 @@ export function DynamicFormBuilder({ fields, values, onChange }: DynamicFormBuil
 
       case 'boolean':
         return (
-          <FormGroup key={field.variable} fieldId={field.variable}>
-            <Checkbox
+          <FormGroup key={field.variable} label={field.short_description} fieldId={field.variable}>
+            <Switch
               id={field.variable}
-              label={field.short_description}
-              description={field.description}
+              label="True"
+              labelOff="False"
               isChecked={value === true || value === 'true'}
               onChange={(_event, checked) => handleChange(field.variable, checked)}
               isDisabled={isFieldDisabled}
             />
+            {field.description && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>{field.description}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
           </FormGroup>
         );
 

--- a/src/components/DynamicFormBuilderWithTracking.tsx
+++ b/src/components/DynamicFormBuilderWithTracking.tsx
@@ -6,8 +6,8 @@ import {
   TextInput,
   FormSelect,
   FormSelectOption,
-  Checkbox,
   FileUpload,
+  Switch,
   FormHelperText,
   HelperText,
   HelperTextItem,
@@ -15,7 +15,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import type { ScenarioField, ScenarioFormValues, TouchedFields, StringField } from '../types/api';
+import type { ScenarioField, ScenarioFormValues, TouchedFields, StringField, EnumField } from '../types/api';
 
 interface DynamicFormBuilderWithTrackingProps {
   fields: ScenarioField[];
@@ -30,10 +30,36 @@ export function DynamicFormBuilderWithTracking({
   values,
   touchedFields,
   onChange,
-  disabledFields = [],
+  disabledFields: externalDisabledFields = [],
 }: DynamicFormBuilderWithTrackingProps) {
   const [errors, setErrors] = useState<{ [key: string]: string }>({});
   const validationTimeouts = useRef<{ [key: string]: number }>({});
+
+  const disabledFields = useMemo(() => {
+    const disabled = new Set<string>(externalDisabledFields);
+    for (const field of fields) {
+      if (field.mutually_excludes && field.type === 'enum') {
+        const enumField = field as EnumField;
+        const opts = enumField.allowed_values
+          .split(enumField.separator)
+          .map((o) => o.trim())
+          .sort();
+        if (opts.length === 2 && opts[0] === 'false' && opts[1] === 'true') {
+          const currentValue = values[field.variable] ?? field.default ?? '';
+          if (currentValue === 'true' || currentValue === true) {
+            disabled.add(field.mutually_excludes);
+          }
+        }
+      }
+      if (field.mutually_excludes && field.type === 'boolean') {
+        const currentValue = values[field.variable] ?? field.default ?? '';
+        if (currentValue === 'true' || currentValue === true) {
+          disabled.add(field.mutually_excludes);
+        }
+      }
+    }
+    return disabled;
+  }, [fields, values, externalDisabledFields]);
 
   /**
    * Safe regex test with timeout protection
@@ -84,6 +110,15 @@ export function DynamicFormBuilderWithTracking({
   const handleChange = (variable: string, value: string | number | boolean | File) => {
     const newValues = { ...values, [variable]: value };
     const newTouchedFields = { ...touchedFields, [variable]: true };
+
+    const changedField = fields.find(f => f.variable === variable);
+    if (changedField?.mutually_excludes && (value === 'true' || value === true)) {
+      const excludedField = fields.find(f => f.variable === changedField.mutually_excludes);
+      if (excludedField) {
+        newValues[changedField.mutually_excludes] = excludedField.default ?? '';
+      }
+    }
+
     onChange(newValues, newTouchedFields);
 
     // Clear existing validation timeout for this field
@@ -128,7 +163,7 @@ export function DynamicFormBuilderWithTracking({
     return members;
   }, [fields]);
 
-  const renderField = (field: ScenarioField) => {
+  const renderField = (field: ScenarioField, isFieldDisabled: boolean = false) => {
     const value = values[field.variable] ?? field.default ?? '';
     const error = errors[field.variable];
     const validated = error ? 'error' : 'default';
@@ -136,7 +171,7 @@ export function DynamicFormBuilderWithTracking({
     switch (field.type) {
       case 'string': {
         const stringField = field as StringField;
-        const isDisabled = disabledFields.includes(field.variable);
+        const isDisabled = disabledFields.has(field.variable);
         return (
           <FormGroup
             key={field.variable}
@@ -152,7 +187,7 @@ export function DynamicFormBuilderWithTracking({
               validated={validated}
               placeholder={field.default}
               autoComplete={field.secret ? 'off' : undefined}
-              isDisabled={isDisabled}
+              isDisabled={isFieldDisabled}
             />
             {field.description && (
               <FormHelperText>
@@ -198,6 +233,7 @@ export function DynamicFormBuilderWithTracking({
               onChange={(_event, val) => handleChange(field.variable, val)}
               validated={validated}
               placeholder={field.default}
+              isDisabled={isFieldDisabled}
             />
             {field.description && (
               <FormHelperText>
@@ -219,7 +255,60 @@ export function DynamicFormBuilderWithTracking({
         );
 
       case 'enum': {
-        const options = (field.allowed_values ?? '').split(field.separator ?? ',').map((opt) => opt.trim()).filter(Boolean);
+        const enumField = field as EnumField;
+
+        if (!enumField.allowed_values || !enumField.separator) {
+          return (
+            <FormGroup
+              key={field.variable}
+              label={field.short_description}
+              isRequired={field.required}
+              fieldId={field.variable}
+            >
+              <TextInput
+                id={field.variable}
+                value={value as string}
+                onChange={(_event, val) => handleChange(field.variable, val)}
+                placeholder="Error: enum configuration missing"
+                isDisabled
+              />
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem variant="error">
+                    Enum field is misconfigured (missing allowed_values or separator)
+                  </HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            </FormGroup>
+          );
+        }
+
+        const options = enumField.allowed_values.split(enumField.separator).map((opt: string) => opt.trim());
+        const sortedOpts = [...options].sort();
+        const isBooleanEnum = sortedOpts.length === 2 && sortedOpts[0] === 'false' && sortedOpts[1] === 'true';
+
+        if (isBooleanEnum) {
+          return (
+            <FormGroup key={field.variable} label={field.short_description} fieldId={field.variable}>
+              <Switch
+                id={field.variable}
+                label="True"
+                labelOff="False"
+                isChecked={value === 'true' || value === true}
+                onChange={(_event, checked) => handleChange(field.variable, checked ? 'true' : 'false')}
+                isDisabled={isFieldDisabled}
+              />
+              {field.description && (
+                <FormHelperText>
+                  <HelperText>
+                    <HelperTextItem>{field.description}</HelperTextItem>
+                  </HelperText>
+                </FormHelperText>
+              )}
+            </FormGroup>
+          );
+        }
+
         return (
           <FormGroup
             key={field.variable}
@@ -232,9 +321,10 @@ export function DynamicFormBuilderWithTracking({
               value={value as string}
               onChange={(_event, val) => handleChange(field.variable, val)}
               validated={validated}
+              isDisabled={isFieldDisabled}
             >
               {!field.required && <FormSelectOption key="empty" value="" label="Select an option" />}
-              {options.map((option) => (
+              {options.map((option: string) => (
                 <FormSelectOption key={option} value={option} label={option} />
               ))}
             </FormSelect>
@@ -260,14 +350,22 @@ export function DynamicFormBuilderWithTracking({
 
       case 'boolean':
         return (
-          <FormGroup key={field.variable} fieldId={field.variable}>
-            <Checkbox
+          <FormGroup key={field.variable} label={field.short_description} fieldId={field.variable}>
+            <Switch
               id={field.variable}
-              label={field.short_description}
-              description={field.description}
+              label="True"
+              labelOff="False"
               isChecked={value === true || value === 'true'}
               onChange={(_event, checked) => handleChange(field.variable, checked)}
+              isDisabled={isFieldDisabled}
             />
+            {field.description && (
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>{field.description}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            )}
           </FormGroup>
         );
 
@@ -286,6 +384,7 @@ export function DynamicFormBuilderWithTracking({
               filename={(value as File)?.name || ''}
               onFileInputChange={(_event, file: File) => handleChange(field.variable, file)}
               validated={validated}
+              isDisabled={isFieldDisabled}
             />
             {field.description && (
               <FormHelperText>
@@ -322,6 +421,7 @@ export function DynamicFormBuilderWithTracking({
               key={groupKey}
               groupField={field}
               members={members}
+              disabledFields={disabledFields}
               renderField={renderField}
             />
           );
@@ -329,7 +429,7 @@ export function DynamicFormBuilderWithTracking({
         if (field.group) {
           return null;
         }
-        return renderField(field);
+        return renderField(field, disabledFields.has(field.variable));
       })}
     </Form>
   );
@@ -340,11 +440,13 @@ const GROUP_CONTAINER_HEIGHT = 400;
 function ScrollableFieldGroupWithTracking({
   groupField,
   members,
+  disabledFields,
   renderField,
 }: {
   groupField: ScenarioField;
   members: ScenarioField[];
-  renderField: (field: ScenarioField) => ReactNode;
+  disabledFields: Set<string>;
+  renderField: (field: ScenarioField, isDisabled: boolean) => ReactNode;
 }) {
   const [search, setSearch] = useState('');
 
@@ -392,7 +494,7 @@ function ScrollableFieldGroupWithTracking({
         />
         <div style={{ maxHeight: `${GROUP_CONTAINER_HEIGHT}px`, overflowY: 'auto' }}>
           {filtered.length > 0 ? (
-            filtered.map((m) => renderField(m))
+            filtered.map((m) => renderField(m, disabledFields.has(m.variable)))
           ) : (
             <FormHelperText>
               <HelperText>


### PR DESCRIPTION
- Replace Checkbox with Switch for type 'boolean' fields in both DynamicFormBuilder and DynamicFormBuilderWithTracking
- Bring DynamicFormBuilderWithTracking to parity with DynamicFormBuilder: add boolean-enum Switch detection, disabledFields support, mutually_excludes reset logic, and isDisabled threading
- Extend disabledFields to support type: 'boolean' fields (previously only worked for enum booleans), enabling related fields to be disabled when a boolean toggle is off

fixes #4 