### PR TITLE
Lazy-load scenario run details and fix resiliency score display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
 
   // Initialize and manage the workflow
   useTargetPoller();
-  useScenarioRunsPoller(); // Poll scenario runs for status updates
+  const { fetchRunDetails } = useScenarioRunsPoller();
   useGraphRunsPoller(); // Poll graph runs for status updates
 
   const handleRetry = () => {
@@ -207,9 +207,16 @@ function App() {
             <JobsList
               expandedRunIds={state.expandedRunIds}
               expandedJobIds={state.expandedClusterJobs}
-              onToggleRunAccordion={(scenarioRunName) =>
-                dispatch({ type: 'TOGGLE_RUN_ACCORDION', payload: { scenarioRunName } })
-              }
+              onToggleRunAccordion={(scenarioRunName) => {
+                const isExpanding = !state.expandedRunIds.has(scenarioRunName);
+                dispatch({ type: 'TOGGLE_RUN_ACCORDION', payload: { scenarioRunName } });
+                if (isExpanding) {
+                  const run = state.scenarioRuns.find(r => r.scenarioRunName === scenarioRunName);
+                  if (run && (!run.clusterJobs || run.clusterJobs.length === 0)) {
+                    fetchRunDetails(scenarioRunName, run);
+                  }
+                }
+              }}
               onToggleJobAccordion={(jobId) =>
                 dispatch({ type: 'TOGGLE_CLUSTER_JOB_ACCORDION', payload: { jobId } })
               }
@@ -223,6 +230,7 @@ function App() {
                 dispatch({ type: 'TOGGLE_GRAPH_RUN_ACCORDION', payload: { graphRunName } })
               }
               onDeleteGraphRun={handleDeleteGraphRun}
+              loadingRunDetails={state.loadingRunDetails}
             />
           </PageSection>
         );

--- a/src/components/JobsList.test.tsx
+++ b/src/components/JobsList.test.tsx
@@ -55,6 +55,7 @@ const defaultProps = {
   onToggleGraphRunAccordion: noop,
   onDeleteGraphRun: noopAsync,
   onRerunScenario: noop,
+  loadingRunDetails: new Set<string>(),
 };
 
 function makeScenarioJobItem(
@@ -229,6 +230,7 @@ describe('JobsList - Re-run button', () => {
     expandedGraphRunIds: new Set<string>(),
     onToggleGraphRunAccordion: vi.fn(),
     onDeleteGraphRun: vi.fn(),
+    loadingRunDetails: new Set<string>(),
   };
 
   beforeEach(() => {

--- a/src/components/JobsList.tsx
+++ b/src/components/JobsList.tsx
@@ -38,7 +38,6 @@ import {
   TextInput,
   Pagination,
   PaginationVariant,
-  Spinner,
 } from '@patternfly/react-core';
 import {
   HourglassHalfIcon,

--- a/src/components/JobsList.tsx
+++ b/src/components/JobsList.tsx
@@ -13,6 +13,7 @@ import {
   DataListContent,
   EmptyState,
   EmptyStateIcon,
+  Spinner,
   EmptyStateBody,
   Title,
   Flex,
@@ -160,6 +161,7 @@ interface JobsListProps {
   expandedGraphRunIds: Set<string>;
   onToggleGraphRunAccordion: (graphRunName: string) => void;
   onDeleteGraphRun: (graphRunName: string) => Promise<void>;
+  loadingRunDetails: Set<string>;
 }
 
 export function JobsList({
@@ -175,6 +177,7 @@ export function JobsList({
   expandedGraphRunIds,
   onToggleGraphRunAccordion,
   onDeleteGraphRun,
+  loadingRunDetails,
 }: JobsListProps) {
   const { isAdmin } = useRole();
   const { activeRuns, loading: activeRunsLoading, error: activeRunsError } = useActiveRunsPoller();
@@ -1243,7 +1246,11 @@ export function JobsList({
                           </div>
                         ) : (
                           <div style={{ padding: '1rem', textAlign: 'center', color: 'var(--pf-v5-global--Color--200)' }}>
-                            No jobs available for this scenario run
+                            {loadingRunDetails.has(run.scenarioRunName) ? (
+                              <Spinner size="lg" aria-label="Loading run details" />
+                            ) : (
+                              'No jobs available for this scenario run'
+                            )}
                           </div>
                         )}
                       </>

--- a/src/components/RegistrySelector.test.tsx
+++ b/src/components/RegistrySelector.test.tsx
@@ -23,6 +23,7 @@ describe('RegistrySelector', () => {
     pollingRunNames: new Set(),
     expandedRunIds: new Set(),
     expandedClusterJobs: new Set(),
+    loadingRunDetails: new Set(),
     graphRuns: [],
     expandedGraphRunIds: new Set(),
     clusters: null,

--- a/src/components/ScenarioDetail.test.tsx
+++ b/src/components/ScenarioDetail.test.tsx
@@ -110,6 +110,7 @@ describe('ScenarioDetail', () => {
     pollingRunNames: new Set(),
     expandedRunIds: new Set(),
     expandedClusterJobs: new Set(),
+    loadingRunDetails: new Set(),
     providers: null,
     providerConfigUuid: null,
     providerConfigStatus: 'idle',

--- a/src/components/__tests__/JobsList.test.tsx
+++ b/src/components/__tests__/JobsList.test.tsx
@@ -272,19 +272,20 @@ describe('JobsList', () => {
 
   describe('Loading Run Details', () => {
     it('should show spinner when run details are loading', () => {
+      setMockJobs([makeScenarioJobItem('loading-run', {
+        scenarioRun: {
+          scenarioRunName: 'loading-run',
+          scenarioName: 'cpu-hog',
+          phase: 'Running',
+          totalTargets: 1,
+          successfulJobs: 0,
+          failedJobs: 0,
+          runningJobs: 1,
+          clusterJobs: [],
+          ownerUserId: 'user@test.com',
+        },
+      })]);
       const props = defaultProps();
-      props.scenarioRuns = [{
-        scenarioRunName: 'loading-run',
-        scenarioName: 'cpu-hog',
-        phase: 'Running' as const,
-        totalTargets: 1,
-        successfulJobs: 0,
-        failedJobs: 0,
-        runningJobs: 1,
-        clusterJobs: [],
-        createdAt: '2026-07-01T08:00:00Z',
-        ownerUserId: 'user@test.com',
-      }];
       props.expandedRunIds = new Set(['loading-run']);
       props.loadingRunDetails = new Set(['loading-run']);
       render(<JobsList {...props} />);
@@ -292,19 +293,20 @@ describe('JobsList', () => {
     });
 
     it('should show "No jobs available" when not loading and no jobs', () => {
+      setMockJobs([makeScenarioJobItem('empty-run', {
+        scenarioRun: {
+          scenarioRunName: 'empty-run',
+          scenarioName: 'cpu-hog',
+          phase: 'Running',
+          totalTargets: 1,
+          successfulJobs: 0,
+          failedJobs: 0,
+          runningJobs: 1,
+          clusterJobs: [],
+          ownerUserId: 'user@test.com',
+        },
+      })]);
       const props = defaultProps();
-      props.scenarioRuns = [{
-        scenarioRunName: 'empty-run',
-        scenarioName: 'cpu-hog',
-        phase: 'Running' as const,
-        totalTargets: 1,
-        successfulJobs: 0,
-        failedJobs: 0,
-        runningJobs: 1,
-        clusterJobs: [],
-        createdAt: '2026-07-01T08:00:00Z',
-        ownerUserId: 'user@test.com',
-      }];
       props.expandedRunIds = new Set(['empty-run']);
       props.loadingRunDetails = new Set();
       render(<JobsList {...props} />);

--- a/src/components/__tests__/JobsList.test.tsx
+++ b/src/components/__tests__/JobsList.test.tsx
@@ -269,4 +269,46 @@ describe('JobsList', () => {
       expect(screen.getByText('cpu-hog')).toBeInTheDocument();
     });
   });
+
+  describe('Loading Run Details', () => {
+    it('should show spinner when run details are loading', () => {
+      const props = defaultProps();
+      props.scenarioRuns = [{
+        scenarioRunName: 'loading-run',
+        scenarioName: 'cpu-hog',
+        phase: 'Running' as const,
+        totalTargets: 1,
+        successfulJobs: 0,
+        failedJobs: 0,
+        runningJobs: 1,
+        clusterJobs: [],
+        createdAt: '2026-07-01T08:00:00Z',
+        ownerUserId: 'user@test.com',
+      }];
+      props.expandedRunIds = new Set(['loading-run']);
+      props.loadingRunDetails = new Set(['loading-run']);
+      render(<JobsList {...props} />);
+      expect(screen.getByLabelText('Loading run details')).toBeInTheDocument();
+    });
+
+    it('should show "No jobs available" when not loading and no jobs', () => {
+      const props = defaultProps();
+      props.scenarioRuns = [{
+        scenarioRunName: 'empty-run',
+        scenarioName: 'cpu-hog',
+        phase: 'Running' as const,
+        totalTargets: 1,
+        successfulJobs: 0,
+        failedJobs: 0,
+        runningJobs: 1,
+        clusterJobs: [],
+        createdAt: '2026-07-01T08:00:00Z',
+        ownerUserId: 'user@test.com',
+      }];
+      props.expandedRunIds = new Set(['empty-run']);
+      props.loadingRunDetails = new Set();
+      render(<JobsList {...props} />);
+      expect(screen.getByText('No jobs available for this scenario run')).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/__tests__/JobsList.test.tsx
+++ b/src/components/__tests__/JobsList.test.tsx
@@ -96,6 +96,7 @@ const defaultProps = () => ({
   onToggleGraphRunAccordion: vi.fn(),
   onDeleteGraphRun: vi.fn().mockResolvedValue(undefined),
   onRerunScenario: vi.fn(),
+  loadingRunDetails: new Set<string>(),
 });
 
 describe('JobsList', () => {

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -15,6 +15,7 @@ const initialState: AppState = {
   pollingRunNames: new Set<string>(),
   expandedRunIds: new Set<string>(),
   expandedClusterJobs: new Set<string>(),
+  loadingRunDetails: new Set<string>(),
 
   // Graph runs list (GraphRun orchestration)
   graphRuns: [],
@@ -235,6 +236,16 @@ function appReducer(state: AppState, action: AppAction): AppState {
       };
     }
 
+    case 'SET_RUN_DETAILS_LOADING': {
+      const newLoading = new Set(state.loadingRunDetails);
+      if (action.payload.loading) {
+        newLoading.add(action.payload.scenarioRunName);
+      } else {
+        newLoading.delete(action.payload.scenarioRunName);
+      }
+      return { ...state, loadingRunDetails: newLoading };
+    }
+
     case 'TOGGLE_CLUSTER_JOB_ACCORDION': {
       const newExpandedJobs = new Set(state.expandedClusterJobs);
       if (newExpandedJobs.has(action.payload.jobId)) {
@@ -253,26 +264,43 @@ function appReducer(state: AppState, action: AppAction): AppState {
       return state; // Graph run created notification - actual data comes via polling
 
     case 'ADD_GRAPH_RUN': {
-      const graphRunExists = state.graphRuns.some(r => r.name === action.payload.run.name);
-      if (graphRunExists) {
+      const existingRun = state.graphRuns.find(r => r.name === action.payload.run.name);
+      const incoming = action.payload.run;
+      if (existingRun) {
+        const merged = {
+          ...existingRun,
+          ...incoming,
+          resiliencyScoreEnabled: incoming.resiliencyScoreEnabled ?? existingRun.resiliencyScoreEnabled,
+          resiliencyScoreBaseline: incoming.resiliencyScoreBaseline ?? existingRun.resiliencyScoreBaseline,
+          resiliencyScore: incoming.resiliencyScore ?? existingRun.resiliencyScore,
+          summary: incoming.summary || existingRun.summary,
+        };
         return {
           ...state,
           graphRuns: state.graphRuns.map(r =>
-            r.name === action.payload.run.name ? action.payload.run : r
+            r.name === incoming.name ? merged : r
           ),
         };
       }
       return {
         ...state,
-        graphRuns: [action.payload.run, ...state.graphRuns],
+        graphRuns: [incoming, ...state.graphRuns],
       };
     }
 
     case 'UPDATE_GRAPH_RUN': {
-      // Update existing graph run
-      const updatedGraphRuns = state.graphRuns.map(run =>
-        run.name === action.payload.run.name ? action.payload.run : run
-      );
+      const updatedGraphRuns = state.graphRuns.map(run => {
+        if (run.name !== action.payload.run.name) return run;
+        const incoming = action.payload.run;
+        return {
+          ...run,
+          ...incoming,
+          resiliencyScoreEnabled: incoming.resiliencyScoreEnabled ?? run.resiliencyScoreEnabled,
+          resiliencyScoreBaseline: incoming.resiliencyScoreBaseline ?? run.resiliencyScoreBaseline,
+          resiliencyScore: incoming.resiliencyScore ?? run.resiliencyScore,
+          summary: incoming.summary || run.summary,
+        };
+      });
       return {
         ...state,
         graphRuns: updatedGraphRuns,

--- a/src/context/__tests__/AppContext.test.tsx
+++ b/src/context/__tests__/AppContext.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, act } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { AppProvider, useAppContext } from '../AppContext';
 import type { GraphRunState, AppAction } from '../../types/api';

--- a/src/context/__tests__/AppContext.test.tsx
+++ b/src/context/__tests__/AppContext.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AppProvider, useAppContext } from '../AppContext';
+import type { GraphRunState, AppAction } from '../../types/api';
+
+let capturedDispatch: React.Dispatch<AppAction>;
+let capturedState: ReturnType<typeof useAppContext>['state'];
+
+function StateReader() {
+  const { state, dispatch } = useAppContext();
+  capturedDispatch = dispatch;
+  capturedState = state;
+  return <div data-testid="loading-details">{JSON.stringify([...state.loadingRunDetails])}</div>;
+}
+
+function renderWithProvider() {
+  return render(
+    <AppProvider>
+      <StateReader />
+    </AppProvider>,
+  );
+}
+
+const makeGraphRun = (overrides: Partial<GraphRunState> = {}): GraphRunState => ({
+  name: 'graph-run-1',
+  namespace: 'krkn-operator-system',
+  creationTimestamp: '2026-01-01T00:00:00Z',
+  phase: 'Running',
+  ownerUserId: 'admin@test.com',
+  targetRequestId: 'target-001',
+  summary: { totalNodes: 2, completedNodes: 0, runningNodes: 2, failedNodes: 0, pendingNodes: 0 },
+  ...overrides,
+});
+
+describe('AppContext reducer', () => {
+  describe('SET_RUN_DETAILS_LOADING', () => {
+    it('adds a run name when loading is true', () => {
+      renderWithProvider();
+
+      act(() => {
+        capturedDispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: 'run-1', loading: true } });
+      });
+
+      expect(capturedState.loadingRunDetails.has('run-1')).toBe(true);
+    });
+
+    it('removes a run name when loading is false', () => {
+      renderWithProvider();
+
+      act(() => {
+        capturedDispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: 'run-1', loading: true } });
+      });
+      act(() => {
+        capturedDispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: 'run-1', loading: false } });
+      });
+
+      expect(capturedState.loadingRunDetails.has('run-1')).toBe(false);
+    });
+
+    it('tracks multiple runs independently', () => {
+      renderWithProvider();
+
+      act(() => {
+        capturedDispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: 'run-1', loading: true } });
+        capturedDispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: 'run-2', loading: true } });
+      });
+      act(() => {
+        capturedDispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: 'run-1', loading: false } });
+      });
+
+      expect(capturedState.loadingRunDetails.has('run-1')).toBe(false);
+      expect(capturedState.loadingRunDetails.has('run-2')).toBe(true);
+    });
+  });
+
+  describe('ADD_GRAPH_RUN', () => {
+    it('adds a new graph run to state', () => {
+      renderWithProvider();
+      const run = makeGraphRun();
+
+      act(() => {
+        capturedDispatch({ type: 'ADD_GRAPH_RUN', payload: { run } });
+      });
+
+      expect(capturedState.graphRuns).toHaveLength(1);
+      expect(capturedState.graphRuns[0].name).toBe('graph-run-1');
+    });
+
+    it('merges with existing run using ?? for resiliency fields', () => {
+      renderWithProvider();
+
+      act(() => {
+        capturedDispatch({
+          type: 'ADD_GRAPH_RUN',
+          payload: {
+            run: makeGraphRun({
+              resiliencyScoreEnabled: true,
+              resiliencyScoreBaseline: 80,
+              resiliencyScore: { calculated: 90, baseline: 80, status: 'pass', message: 'ok' },
+            }),
+          },
+        });
+      });
+
+      act(() => {
+        capturedDispatch({
+          type: 'ADD_GRAPH_RUN',
+          payload: {
+            run: makeGraphRun({
+              phase: 'Completed',
+              resiliencyScoreEnabled: undefined,
+              resiliencyScoreBaseline: undefined,
+              resiliencyScore: undefined,
+            }),
+          },
+        });
+      });
+
+      const run = capturedState.graphRuns.find(r => r.name === 'graph-run-1')!;
+      expect(run.phase).toBe('Completed');
+      expect(run.resiliencyScoreEnabled).toBe(true);
+      expect(run.resiliencyScoreBaseline).toBe(80);
+      expect(run.resiliencyScore?.calculated).toBe(90);
+    });
+  });
+
+  describe('UPDATE_GRAPH_RUN', () => {
+    it('preserves existing resiliency fields when incoming is undefined', () => {
+      renderWithProvider();
+
+      act(() => {
+        capturedDispatch({
+          type: 'LOAD_GRAPH_RUNS_SUCCESS',
+          payload: {
+            runs: [makeGraphRun({
+              resiliencyScoreEnabled: true,
+              resiliencyScoreBaseline: 80,
+              resiliencyScore: { calculated: 85, baseline: 80, status: 'pass', message: 'ok' },
+            })],
+          },
+        });
+      });
+
+      act(() => {
+        capturedDispatch({
+          type: 'UPDATE_GRAPH_RUN',
+          payload: {
+            run: makeGraphRun({
+              phase: 'Completed',
+              resiliencyScoreEnabled: undefined,
+              resiliencyScoreBaseline: undefined,
+              resiliencyScore: undefined,
+            }),
+          },
+        });
+      });
+
+      const run = capturedState.graphRuns[0];
+      expect(run.phase).toBe('Completed');
+      expect(run.resiliencyScoreEnabled).toBe(true);
+      expect(run.resiliencyScoreBaseline).toBe(80);
+      expect(run.resiliencyScore?.calculated).toBe(85);
+    });
+
+    it('overwrites resiliency fields when incoming has values', () => {
+      renderWithProvider();
+
+      act(() => {
+        capturedDispatch({
+          type: 'LOAD_GRAPH_RUNS_SUCCESS',
+          payload: {
+            runs: [makeGraphRun({
+              resiliencyScore: { calculated: 70, baseline: 80, status: 'fail', message: 'old' },
+            })],
+          },
+        });
+      });
+
+      act(() => {
+        capturedDispatch({
+          type: 'UPDATE_GRAPH_RUN',
+          payload: {
+            run: makeGraphRun({
+              resiliencyScore: { calculated: 90, baseline: 80, status: 'pass', message: 'new' },
+            }),
+          },
+        });
+      });
+
+      expect(capturedState.graphRuns[0].resiliencyScore?.calculated).toBe(90);
+      expect(capturedState.graphRuns[0].resiliencyScore?.status).toBe('pass');
+    });
+  });
+});

--- a/src/hooks/__tests__/useGraphRunsPoller.test.tsx
+++ b/src/hooks/__tests__/useGraphRunsPoller.test.tsx
@@ -1,0 +1,299 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ServerMessage } from '../../types/websocket';
+import type { GraphRunState, GraphRunListItem } from '../../types/api';
+
+const mockDispatch = vi.fn();
+let mockGraphRuns: GraphRunState[] = [];
+
+vi.mock('../../context/AppContext', () => ({
+  useAppContext: () => ({
+    state: { graphRuns: mockGraphRuns },
+    dispatch: mockDispatch,
+  }),
+}));
+
+let capturedHandler: ((msg: ServerMessage) => void) | null = null;
+const mockConnectionState = { value: 'disconnected' as string };
+
+vi.mock('../useWebSocket', () => ({
+  useWebSocket: (_id: string, _url: string, handler: (msg: ServerMessage) => void) => {
+    capturedHandler = handler;
+    return { connectionState: mockConnectionState.value };
+  },
+}));
+
+vi.mock('../../services', () => ({
+  graphRunsApi: { listGraphRuns: vi.fn() },
+}));
+
+vi.mock('../../services/websocketService', () => ({
+  websocketService: {
+    buildResourceUrl: vi.fn(() => 'ws://localhost/api/v2/ws/graphruns'),
+    subscribe: vi.fn(),
+  },
+}));
+
+vi.mock('../../utils/resiliency', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/resiliency')>();
+  return { ...actual };
+});
+
+import { graphRunsApi } from '../../services';
+import { useGraphRunsPoller } from '../useGraphRunsPoller';
+
+function makeGraphRunListItem(overrides: Partial<GraphRunListItem> = {}): GraphRunListItem {
+  return {
+    name: 'graphrun-001',
+    namespace: 'krkn-operator-system',
+    creationTimestamp: '2025-06-15T10:00:00Z',
+    phase: 'Running',
+    ownerUserId: 'user@example.com',
+    targetRequestId: 'tr-001',
+    summary: { totalNodes: 3, completedNodes: 1, runningNodes: 1, failedNodes: 0, pendingNodes: 1 },
+    ...overrides,
+  };
+}
+
+function makeGraphRunState(overrides: Partial<GraphRunState> = {}): GraphRunState {
+  return {
+    name: 'graphrun-001',
+    namespace: 'krkn-operator-system',
+    creationTimestamp: '2025-06-15T10:00:00Z',
+    phase: 'Running',
+    ownerUserId: 'user@example.com',
+    targetRequestId: 'tr-001',
+    summary: { totalNodes: 3, completedNodes: 1, runningNodes: 1, failedNodes: 0, pendingNodes: 1 },
+    ...overrides,
+  };
+}
+
+function sendWsMessage(msg: ServerMessage) {
+  const { act } = require('@testing-library/react');
+  act(() => { capturedHandler?.(msg); });
+}
+
+describe('useGraphRunsPoller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedHandler = null;
+    mockGraphRuns = [];
+    mockConnectionState.value = 'disconnected';
+  });
+
+  describe('REST aggregation', () => {
+    it('aggregates resiliencyScore from resiliencyScores on REST fetch', async () => {
+      const runFromApi = makeGraphRunListItem({
+        resiliencyScores: [
+          { clusterName: 'cluster-a', calculated: 85, baseline: 80, status: 'pass' },
+          { clusterName: 'cluster-b', calculated: 75, baseline: 80, status: 'pass' },
+        ],
+        resiliencyScoreBaseline: 80,
+        resiliencyScore: undefined,
+      });
+
+      vi.mocked(graphRunsApi.listGraphRuns).mockResolvedValue([runFromApi]);
+      mockConnectionState.value = 'connected';
+
+      renderHook(() => useGraphRunsPoller());
+
+      await vi.waitFor(() => {
+        expect(mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'LOAD_GRAPH_RUNS_SUCCESS',
+            payload: {
+              runs: expect.arrayContaining([
+                expect.objectContaining({
+                  name: 'graphrun-001',
+                  resiliencyScore: {
+                    calculated: 80,
+                    baseline: 80,
+                    status: 'pass',
+                    message: 'cluster-a: 85, cluster-b: 75',
+                  },
+                }),
+              ]),
+            },
+          }),
+        );
+      });
+    });
+
+    it('uses existing resiliencyScore when no resiliencyScores on REST fetch', async () => {
+      const existingScore = { calculated: 90, baseline: 80, status: 'pass' as const, message: 'ok' };
+      const runFromApi = makeGraphRunListItem({
+        resiliencyScores: undefined,
+        resiliencyScore: existingScore,
+      });
+
+      vi.mocked(graphRunsApi.listGraphRuns).mockResolvedValue([runFromApi]);
+      mockConnectionState.value = 'connected';
+
+      renderHook(() => useGraphRunsPoller());
+
+      await vi.waitFor(() => {
+        expect(mockDispatch).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'LOAD_GRAPH_RUNS_SUCCESS',
+            payload: {
+              runs: expect.arrayContaining([
+                expect.objectContaining({
+                  name: 'graphrun-001',
+                  resiliencyScore: existingScore,
+                }),
+              ]),
+            },
+          }),
+        );
+      });
+    });
+  });
+
+  describe('WS handler', () => {
+    beforeEach(() => {
+      mockConnectionState.value = 'connected';
+      vi.mocked(graphRunsApi.listGraphRuns).mockResolvedValue([]);
+    });
+
+    it('computes resiliencyScore from scores on WS update when data.resiliencyScore is absent', () => {
+      mockGraphRuns = [makeGraphRunState({ name: 'graphrun-001' })];
+      renderHook(() => useGraphRunsPoller());
+
+      sendWsMessage({
+        resource: 'graphrun',
+        id: 'graphrun-001',
+        event: 'updated',
+        data: {
+          phase: 'Completed',
+          resiliencyScores: [
+            { clusterName: 'cluster-a', calculated: 90, baseline: 80, status: 'pass' },
+            { clusterName: 'cluster-b', calculated: 70, baseline: 80, status: 'pass' },
+          ],
+          resiliencyScoreBaseline: 80,
+        },
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'UPDATE_GRAPH_RUN',
+          payload: expect.objectContaining({
+            run: expect.objectContaining({
+              resiliencyScore: {
+                calculated: 80,
+                baseline: 80,
+                status: 'pass',
+                message: 'cluster-a: 90, cluster-b: 70',
+              },
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('prefers data.resiliencyScore over aggregation on WS update', () => {
+      mockGraphRuns = [makeGraphRunState({ name: 'graphrun-001' })];
+      renderHook(() => useGraphRunsPoller());
+
+      const explicitScore = { calculated: 99, baseline: 80, status: 'pass' as const, message: 'explicit' };
+
+      sendWsMessage({
+        resource: 'graphrun',
+        id: 'graphrun-001',
+        event: 'updated',
+        data: {
+          phase: 'Completed',
+          resiliencyScore: explicitScore,
+          resiliencyScores: [
+            { clusterName: 'cluster-a', calculated: 50, baseline: 80, status: 'fail' },
+          ],
+          resiliencyScoreBaseline: 80,
+        },
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'UPDATE_GRAPH_RUN',
+          payload: expect.objectContaining({
+            run: expect.objectContaining({
+              resiliencyScore: explicitScore,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('falls back to existing resiliencyScore when WS has neither scores nor resiliencyScore', () => {
+      const existingScore = { calculated: 85, baseline: 80, status: 'pass' as const, message: 'existing' };
+      mockGraphRuns = [makeGraphRunState({ name: 'graphrun-001', resiliencyScore: existingScore })];
+      renderHook(() => useGraphRunsPoller());
+
+      sendWsMessage({
+        resource: 'graphrun',
+        id: 'graphrun-001',
+        event: 'updated',
+        data: {
+          phase: 'Completed',
+        },
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'UPDATE_GRAPH_RUN',
+          payload: expect.objectContaining({
+            run: expect.objectContaining({
+              resiliencyScore: existingScore,
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('provides default summary when WS created event has no summary and no existing run', () => {
+      mockGraphRuns = [];
+      renderHook(() => useGraphRunsPoller());
+
+      sendWsMessage({
+        resource: 'graphrun',
+        id: 'graphrun-new',
+        event: 'created',
+        data: {
+          phase: 'Pending',
+          namespace: 'krkn-operator-system',
+          ownerUserId: 'user@example.com',
+          targetRequestId: 'tr-002',
+        },
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'ADD_GRAPH_RUN',
+          payload: expect.objectContaining({
+            run: expect.objectContaining({
+              name: 'graphrun-new',
+              summary: { totalNodes: 0, completedNodes: 0, runningNodes: 0, failedNodes: 0, pendingNodes: 0 },
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('dispatches DELETE_GRAPH_RUN on deleted event', () => {
+      mockGraphRuns = [makeGraphRunState({ name: 'graphrun-001' })];
+      renderHook(() => useGraphRunsPoller());
+
+      sendWsMessage({
+        resource: 'graphrun',
+        id: 'graphrun-001',
+        event: 'deleted',
+        data: {},
+      });
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'DELETE_GRAPH_RUN',
+          payload: { graphRunName: 'graphrun-001' },
+        }),
+      );
+    });
+  });
+});

--- a/src/hooks/__tests__/useGraphRunsPoller.test.tsx
+++ b/src/hooks/__tests__/useGraphRunsPoller.test.tsx
@@ -68,8 +68,8 @@ function makeGraphRunState(overrides: Partial<GraphRunState> = {}): GraphRunStat
   };
 }
 
-function sendWsMessage(msg: ServerMessage) {
-  const { act } = require('@testing-library/react');
+async function sendWsMessage(msg: ServerMessage) {
+  const { act } = await import('@testing-library/react');
   act(() => { capturedHandler?.(msg); });
 }
 
@@ -155,11 +155,11 @@ describe('useGraphRunsPoller', () => {
       vi.mocked(graphRunsApi.listGraphRuns).mockResolvedValue([]);
     });
 
-    it('computes resiliencyScore from scores on WS update when data.resiliencyScore is absent', () => {
+    it('computes resiliencyScore from scores on WS update when data.resiliencyScore is absent', async () => {
       mockGraphRuns = [makeGraphRunState({ name: 'graphrun-001' })];
       renderHook(() => useGraphRunsPoller());
 
-      sendWsMessage({
+      await sendWsMessage({
         resource: 'graphrun',
         id: 'graphrun-001',
         event: 'updated',
@@ -190,13 +190,13 @@ describe('useGraphRunsPoller', () => {
       );
     });
 
-    it('prefers data.resiliencyScore over aggregation on WS update', () => {
+    it('prefers data.resiliencyScore over aggregation on WS update', async () => {
       mockGraphRuns = [makeGraphRunState({ name: 'graphrun-001' })];
       renderHook(() => useGraphRunsPoller());
 
       const explicitScore = { calculated: 99, baseline: 80, status: 'pass' as const, message: 'explicit' };
 
-      sendWsMessage({
+      await sendWsMessage({
         resource: 'graphrun',
         id: 'graphrun-001',
         event: 'updated',
@@ -222,12 +222,12 @@ describe('useGraphRunsPoller', () => {
       );
     });
 
-    it('falls back to existing resiliencyScore when WS has neither scores nor resiliencyScore', () => {
+    it('falls back to existing resiliencyScore when WS has neither scores nor resiliencyScore', async () => {
       const existingScore = { calculated: 85, baseline: 80, status: 'pass' as const, message: 'existing' };
       mockGraphRuns = [makeGraphRunState({ name: 'graphrun-001', resiliencyScore: existingScore })];
       renderHook(() => useGraphRunsPoller());
 
-      sendWsMessage({
+      await sendWsMessage({
         resource: 'graphrun',
         id: 'graphrun-001',
         event: 'updated',
@@ -248,11 +248,11 @@ describe('useGraphRunsPoller', () => {
       );
     });
 
-    it('provides default summary when WS created event has no summary and no existing run', () => {
+    it('provides default summary when WS created event has no summary and no existing run', async () => {
       mockGraphRuns = [];
       renderHook(() => useGraphRunsPoller());
 
-      sendWsMessage({
+      await sendWsMessage({
         resource: 'graphrun',
         id: 'graphrun-new',
         event: 'created',
@@ -277,11 +277,11 @@ describe('useGraphRunsPoller', () => {
       );
     });
 
-    it('dispatches DELETE_GRAPH_RUN on deleted event', () => {
+    it('dispatches DELETE_GRAPH_RUN on deleted event', async () => {
       mockGraphRuns = [makeGraphRunState({ name: 'graphrun-001' })];
       renderHook(() => useGraphRunsPoller());
 
-      sendWsMessage({
+      await sendWsMessage({
         resource: 'graphrun',
         id: 'graphrun-001',
         event: 'deleted',

--- a/src/hooks/__tests__/useScenarioRunsPoller.integration.test.tsx
+++ b/src/hooks/__tests__/useScenarioRunsPoller.integration.test.tsx
@@ -259,3 +259,130 @@ describe('useScenarioRunsPoller handleMessage integration', () => {
     expect(mockDispatch).not.toHaveBeenCalled();
   });
 });
+
+describe('useScenarioRunsPoller fetchRunDetails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedHandler = null;
+    mockScenarioRuns = [];
+    mockConnectionState.value = 'connected';
+  });
+
+  it('dispatches SET_RUN_DETAILS_LOADING true then false around fetch', async () => {
+    const details: ScenarioRunStatusResponse = {
+      scenarioRunName: 'run-001',
+      phase: 'Running',
+      totalTargets: 1,
+      successfulJobs: 0,
+      failedJobs: 0,
+      runningJobs: 1,
+      clusterJobs: [{ providerName: 'krkn', clusterName: 'c1', jobId: 'j1', podName: 'p1', phase: 'Running', startTime: '' }],
+    };
+    vi.mocked(operatorApi.getScenarioRunStatus).mockResolvedValue(details);
+
+    const { result } = renderHook(() => useScenarioRunsPoller());
+    const base = makeRunState();
+
+    await act(async () => {
+      await result.current.fetchRunDetails('run-001', base);
+    });
+
+    const loadingCalls = mockDispatch.mock.calls.filter(
+      ([a]) => a.type === 'SET_RUN_DETAILS_LOADING' && a.payload.scenarioRunName === 'run-001',
+    );
+    expect(loadingCalls).toHaveLength(2);
+    expect(loadingCalls[0][0].payload.loading).toBe(true);
+    expect(loadingCalls[1][0].payload.loading).toBe(false);
+  });
+
+  it('skips fetch when already in-flight for the same run', async () => {
+    let resolveFirst: () => void;
+    const blockingPromise = new Promise<ScenarioRunStatusResponse>((resolve) => {
+      resolveFirst = () => resolve({
+        scenarioRunName: 'run-001',
+        phase: 'Running',
+        totalTargets: 1,
+        successfulJobs: 0,
+        failedJobs: 0,
+        runningJobs: 1,
+        clusterJobs: [{ providerName: 'krkn', clusterName: 'c1', jobId: 'j1', podName: 'p1', phase: 'Running', startTime: '' }],
+      });
+    });
+    vi.mocked(operatorApi.getScenarioRunStatus).mockReturnValue(blockingPromise);
+
+    const { result } = renderHook(() => useScenarioRunsPoller());
+    const base = makeRunState();
+
+    act(() => {
+      result.current.fetchRunDetails('run-001', base);
+    });
+
+    await act(async () => {
+      await result.current.fetchRunDetails('run-001', base);
+    });
+
+    expect(operatorApi.getScenarioRunStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => { resolveFirst!(); });
+  });
+
+  it('clears fetchedDetails when API returns empty clusterJobs', async () => {
+    const emptyDetails: ScenarioRunStatusResponse = {
+      scenarioRunName: 'run-001',
+      phase: 'Running',
+      totalTargets: 1,
+      successfulJobs: 0,
+      failedJobs: 0,
+      runningJobs: 1,
+      clusterJobs: [],
+    };
+    vi.mocked(operatorApi.getScenarioRunStatus).mockResolvedValue(emptyDetails);
+
+    const { result } = renderHook(() => useScenarioRunsPoller());
+    const base = makeRunState();
+
+    await act(async () => {
+      await result.current.fetchRunDetails('run-001', base);
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'UPDATE_SCENARIO_RUN' }),
+    );
+
+    vi.mocked(operatorApi.getScenarioRunStatus).mockResolvedValue({
+      ...emptyDetails,
+      clusterJobs: [{ providerName: 'krkn', clusterName: 'c1', jobId: 'j1', podName: 'p1', phase: 'Running', startTime: '' }],
+    });
+
+    await act(async () => {
+      await result.current.fetchRunDetails('run-001', base);
+    });
+
+    expect(operatorApi.getScenarioRunStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('preserves terminal phase in dispatched update', async () => {
+    const details: ScenarioRunStatusResponse = {
+      scenarioRunName: 'run-001',
+      phase: 'Running',
+      totalTargets: 1,
+      successfulJobs: 1,
+      failedJobs: 0,
+      runningJobs: 0,
+      clusterJobs: [{ providerName: 'krkn', clusterName: 'c1', jobId: 'j1', podName: 'p1', phase: 'Succeeded', startTime: '' }],
+    };
+    vi.mocked(operatorApi.getScenarioRunStatus).mockResolvedValue(details);
+
+    const { result } = renderHook(() => useScenarioRunsPoller());
+    const base = makeRunState({ phase: 'Succeeded' });
+
+    await act(async () => {
+      await result.current.fetchRunDetails('run-001', base);
+    });
+
+    const updateCall = mockDispatch.mock.calls.find(([a]) => a.type === 'UPDATE_SCENARIO_RUN');
+    expect(updateCall).toBeDefined();
+    expect(updateCall![0].payload.run.phase).toBe('Succeeded');
+    expect(updateCall![0].payload.run.clusterJobs).toEqual(details.clusterJobs);
+  });
+});

--- a/src/hooks/useGraphRunsPoller.ts
+++ b/src/hooks/useGraphRunsPoller.ts
@@ -4,18 +4,8 @@ import { graphRunsApi } from '../services';
 import { useWebSocket } from './useWebSocket';
 import { websocketService } from '../services/websocketService';
 import type { ServerMessage } from '../types/websocket';
-import type { GraphRunState, GraphClusterScore, ResiliencyScoreResponse } from '../types/api';
-
-function aggregateResiliencyScores(scores: GraphClusterScore[]): ResiliencyScoreResponse {
-  const avg = scores.reduce((sum, s) => sum + s.calculated, 0) / scores.length;
-  const hasFail = scores.some(s => s.status === 'fail');
-  return {
-    calculated: avg,
-    baseline: scores[0]?.baseline,
-    status: hasFail ? 'fail' : 'pass',
-    message: scores.map(s => `${s.clusterName}: ${s.calculated}`).join(', '),
-  };
-}
+import type { GraphRunState } from '../types/api';
+import { aggregateResiliencyScores } from '../utils/resiliency';
 
 /**
  * Hook to receive real-time graph run updates via WebSocket.
@@ -39,7 +29,7 @@ export function useGraphRunsPoller() {
       const graphRuns = await graphRunsApi.listGraphRuns();
       const graphRunStates: GraphRunState[] = graphRuns.map((run) => {
         const resiliencyScore = run.resiliencyScores?.length
-          ? aggregateResiliencyScores(run.resiliencyScores)
+          ? aggregateResiliencyScores(run.resiliencyScores, run.resiliencyScoreBaseline)
           : run.resiliencyScore;
 
         return {
@@ -91,6 +81,14 @@ export function useGraphRunsPoller() {
         resiliencyScoreBaseline: data.resiliencyScoreBaseline ?? existing?.resiliencyScoreBaseline ?? data.resiliencyScores?.[0]?.baseline,
         resiliencyScores: data.resiliencyScores ?? existing?.resiliencyScores,
       };
+
+      const scores = updatedState.resiliencyScores;
+      if (scores?.length) {
+        updatedState.resiliencyScore = data.resiliencyScore
+          ?? aggregateResiliencyScores(scores, updatedState.resiliencyScoreBaseline);
+      } else {
+        updatedState.resiliencyScore = data.resiliencyScore ?? existing?.resiliencyScore;
+      }
 
       if (existing) {
         dispatch({ type: 'UPDATE_GRAPH_RUN', payload: { run: updatedState } });

--- a/src/hooks/useGraphRunsPoller.ts
+++ b/src/hooks/useGraphRunsPoller.ts
@@ -4,7 +4,18 @@ import { graphRunsApi } from '../services';
 import { useWebSocket } from './useWebSocket';
 import { websocketService } from '../services/websocketService';
 import type { ServerMessage } from '../types/websocket';
-import type { GraphRunState } from '../types/api';
+import type { GraphRunState, GraphClusterScore, ResiliencyScoreResponse } from '../types/api';
+
+function aggregateResiliencyScores(scores: GraphClusterScore[]): ResiliencyScoreResponse {
+  const avg = scores.reduce((sum, s) => sum + s.calculated, 0) / scores.length;
+  const hasFail = scores.some(s => s.status === 'fail');
+  return {
+    calculated: avg,
+    baseline: scores[0]?.baseline,
+    status: hasFail ? 'fail' : 'pass',
+    message: scores.map(s => `${s.clusterName}: ${s.calculated}`).join(', '),
+  };
+}
 
 /**
  * Hook to receive real-time graph run updates via WebSocket.
@@ -26,20 +37,27 @@ export function useGraphRunsPoller() {
 
     try {
       const graphRuns = await graphRunsApi.listGraphRuns();
-      const graphRunStates: GraphRunState[] = graphRuns.map((run) => ({
-        name: run.name,
-        namespace: run.namespace,
-        creationTimestamp: run.creationTimestamp,
-        phase: run.phase,
-        ownerUserId: run.ownerUserId,
-        targetRequestId: run.targetRequestId,
-        summary: run.summary,
-        startTime: run.startTime,
-        completionTime: run.completionTime,
-        resiliencyScoreEnabled: run.resiliencyScoreEnabled,
-        resiliencyScoreBaseline: run.resiliencyScoreBaseline,
-        resiliencyScores: run.resiliencyScores,
-      }));
+      const graphRunStates: GraphRunState[] = graphRuns.map((run) => {
+        const resiliencyScore = run.resiliencyScores?.length
+          ? aggregateResiliencyScores(run.resiliencyScores)
+          : run.resiliencyScore;
+
+        return {
+          name: run.name,
+          namespace: run.namespace,
+          creationTimestamp: run.creationTimestamp,
+          phase: run.phase,
+          ownerUserId: run.ownerUserId,
+          targetRequestId: run.targetRequestId,
+          summary: run.summary,
+          startTime: run.startTime,
+          completionTime: run.completionTime,
+          resiliencyScoreEnabled: run.resiliencyScoreEnabled,
+          resiliencyScoreBaseline: run.resiliencyScoreBaseline,
+          resiliencyScores: run.resiliencyScores,
+          resiliencyScore,
+        };
+      });
 
       dispatch({
         type: 'LOAD_GRAPH_RUNS_SUCCESS',
@@ -66,7 +84,7 @@ export function useGraphRunsPoller() {
         phase: data.phase,
         ownerUserId: data.ownerUserId || existing?.ownerUserId || '',
         targetRequestId: data.targetRequestId || existing?.targetRequestId || '',
-        summary: data.summary || existing?.summary,
+        summary: data.summary || existing?.summary || { totalNodes: 0, completedNodes: 0, runningNodes: 0, failedNodes: 0, pendingNodes: 0 },
         startTime: data.startTime || existing?.startTime,
         completionTime: data.completionTime || existing?.completionTime,
         resiliencyScoreEnabled: data.resiliencyScoreEnabled ?? existing?.resiliencyScoreEnabled,

--- a/src/hooks/useScenarioRunsPoller.ts
+++ b/src/hooks/useScenarioRunsPoller.ts
@@ -17,7 +17,9 @@ export function useScenarioRunsPoller() {
   const { state, dispatch } = useAppContext();
 
   const scenarioRunsRef = useRef(state.scenarioRuns);
+  const expandedRunIdsRef = useRef(state.expandedRunIds);
   scenarioRunsRef.current = state.scenarioRuns;
+  expandedRunIdsRef.current = state.expandedRunIds;
 
   const initialFetchDoneRef = useRef(false);
   const fetchedDetailsRef = useRef<Set<string>>(new Set());
@@ -27,6 +29,7 @@ export function useScenarioRunsPoller() {
     if (fetchedDetailsRef.current.has(runName)) return;
     fetchedDetailsRef.current.add(runName);
 
+    dispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: runName, loading: true } });
     try {
       const details = await operatorApi.getScenarioRunStatus(runName);
       if (!details.clusterJobs || details.clusterJobs.length === 0) {
@@ -58,6 +61,8 @@ export function useScenarioRunsPoller() {
       });
     } catch {
       fetchedDetailsRef.current.delete(runName);
+    } finally {
+      dispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: runName, loading: false } });
     }
   }, [dispatch]);
 
@@ -93,17 +98,10 @@ export function useScenarioRunsPoller() {
         type: 'LOAD_SCENARIO_RUNS_SUCCESS',
         payload: { runs: scenarioRunStates },
       });
-
-      const runsWithoutJobs = scenarioRunStates.filter(
-        (run) => !run.clusterJobs || run.clusterJobs.length === 0
-      );
-      for (const run of runsWithoutJobs) {
-        fetchRunDetails(run.scenarioRunName, run);
-      }
     } catch {
       initialFetchDoneRef.current = false;
     }
-  }, [dispatch, fetchRunDetails]);
+  }, [dispatch]);
 
   const handleMessage = useCallback((message: ServerMessage) => {
     if (message.resource !== 'run') return;
@@ -150,8 +148,8 @@ export function useScenarioRunsPoller() {
         dispatch({ type: 'ADD_SCENARIO_RUN', payload: { run: updatedState } });
       }
 
-      // Fetch details if no clusterJobs from either source
-      if (!hasWsJobs && (!existing || existing.clusterJobs.length === 0)) {
+      // Only fetch details via WS if the run is currently expanded
+      if (!hasWsJobs && (!existing || existing.clusterJobs.length === 0) && expandedRunIdsRef.current.has(runName)) {
         fetchRunDetails(runName, updatedState);
       }
     } else if (message.event === 'deleted') {
@@ -174,6 +172,29 @@ export function useScenarioRunsPoller() {
     }
   }, [connectionState, fetchInitialScenarioRuns]);
 
+  // Periodically re-fetch details for expanded runs that are still active.
+  // Keeps clusterJob phases up-to-date until the per-run detail WebSocket is implemented.
+  useEffect(() => {
+    if (connectionState !== 'connected') return;
+
+    const intervalId = setInterval(() => {
+      const expandedIds = state.expandedRunIds;
+      const runs = scenarioRunsRef.current;
+
+      for (const runName of expandedIds) {
+        const run = runs.find(r => r.scenarioRunName === runName);
+        if (!run) continue;
+        if (['Succeeded', 'Failed', 'PartiallyFailed'].includes(run.phase)) continue;
+
+        fetchedDetailsRef.current.delete(runName);
+        fetchRunDetails(runName, run);
+      }
+    }, 5000);
+
+    return () => clearInterval(intervalId);
+  }, [connectionState, state.expandedRunIds, fetchRunDetails]);
+
+  return { fetchRunDetails };
 }
 
 /**

--- a/src/hooks/useScenarioRunsPoller.ts
+++ b/src/hooks/useScenarioRunsPoller.ts
@@ -24,9 +24,13 @@ export function useScenarioRunsPoller() {
   const initialFetchDoneRef = useRef(false);
   const fetchedDetailsRef = useRef<Set<string>>(new Set());
   const terminalFetchDoneRef = useRef<Set<string>>(new Set());
+  const inFlightRef = useRef<Set<string>>(new Set());
 
   const fetchRunDetails = useCallback(async (runName: string, base: ScenarioRunState) => {
+    if (inFlightRef.current.has(runName)) return;
     if (fetchedDetailsRef.current.has(runName)) return;
+
+    inFlightRef.current.add(runName);
     fetchedDetailsRef.current.add(runName);
 
     dispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: runName, loading: true } });
@@ -62,6 +66,7 @@ export function useScenarioRunsPoller() {
     } catch {
       fetchedDetailsRef.current.delete(runName);
     } finally {
+      inFlightRef.current.delete(runName);
       dispatch({ type: 'SET_RUN_DETAILS_LOADING', payload: { scenarioRunName: runName, loading: false } });
     }
   }, [dispatch]);
@@ -185,6 +190,7 @@ export function useScenarioRunsPoller() {
         const run = runs.find(r => r.scenarioRunName === runName);
         if (!run) continue;
         if (['Succeeded', 'Failed', 'PartiallyFailed'].includes(run.phase)) continue;
+        if (inFlightRef.current.has(runName)) continue;
 
         fetchedDetailsRef.current.delete(runName);
         fetchRunDetails(runName, run);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -443,6 +443,7 @@ export interface AppState {
   pollingRunNames: Set<string>;
   expandedRunIds: Set<string>;
   expandedClusterJobs: Set<string>; // jobId
+  loadingRunDetails: Set<string>;
 
   // Graph runs list (GraphRun orchestration)
   graphRuns: GraphRunState[];
@@ -502,6 +503,7 @@ export type AppAction =
   | { type: 'LOAD_SCENARIO_RUNS_SUCCESS'; payload: { runs: ScenarioRunState[] } }
   | { type: 'TOGGLE_RUN_ACCORDION'; payload: { scenarioRunName: string } }
   | { type: 'TOGGLE_CLUSTER_JOB_ACCORDION'; payload: { jobId: string } }
+  | { type: 'SET_RUN_DETAILS_LOADING'; payload: { scenarioRunName: string; loading: boolean } }
 
   // Graph runs list management
   | { type: 'GRAPH_RUN_CREATED'; payload: { graphRunName: string; totalNodes: number } }
@@ -865,6 +867,7 @@ export interface GraphRunListItem {
   // Resiliency score fields
   resiliencyScoreEnabled?: boolean;
   resiliencyScoreBaseline?: number;
+  resiliencyScore?: ResiliencyScoreResponse;
   resiliencyScores?: GraphClusterScore[];
 }
 
@@ -943,6 +946,8 @@ export interface GraphRunState {
   resiliencyScoreEnabled?: boolean;
   resiliencyScoreBaseline?: number;
   resiliencyScores?: GraphClusterScore[];
+  /** Aggregated resiliency score (computed from resiliencyScores) */
+  resiliencyScore?: ResiliencyScoreResponse;
 }
 
 /**

--- a/src/utils/__tests__/resiliency.test.ts
+++ b/src/utils/__tests__/resiliency.test.ts
@@ -7,6 +7,7 @@ import {
   calculateNodeScoreAverage,
   isScoreCalculating,
   SCORE_CALCULATING,
+  aggregateResiliencyScores,
 } from '../resiliency';
 import type { ClusterResiliencyScore, GraphClusterScore } from '../../types/api';
 
@@ -176,5 +177,105 @@ describe('isScoreCalculating', () => {
 
   it('returns false for empty array', () => {
     expect(isScoreCalculating([])).toBe(false);
+  });
+});
+
+describe('aggregateResiliencyScores', () => {
+  it('returns pass when all clusters pass', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 90, baseline: 80, status: 'pass' },
+      { clusterName: 'b', calculated: 80, baseline: 80, status: 'pass' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.status).toBe('pass');
+    expect(result.calculated).toBe(85);
+    expect(result.baseline).toBe(80);
+  });
+
+  it('returns fail when any cluster fails', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 90, baseline: 80, status: 'pass' },
+      { clusterName: 'b', calculated: 50, baseline: 80, status: 'fail' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.status).toBe('fail');
+  });
+
+  it('returns no-baseline when any cluster has no-baseline status', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 90, baseline: 80, status: 'pass' },
+      { clusterName: 'b', calculated: 85, status: 'no-baseline' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.status).toBe('no-baseline');
+  });
+
+  it('returns no-baseline when baseline is missing from all clusters', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 90, status: 'pass' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.status).toBe('no-baseline');
+  });
+
+  it('returns no-baseline when baseline is zero', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 90, baseline: 0, status: 'pass' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.status).toBe('no-baseline');
+  });
+
+  it('returns no-baseline when baseline is negative', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 90, baseline: -5, status: 'pass' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.status).toBe('no-baseline');
+  });
+
+  it('fail takes precedence over no-baseline', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 50, baseline: 80, status: 'fail' },
+      { clusterName: 'b', calculated: 85, status: 'no-baseline' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.status).toBe('fail');
+  });
+
+  it('uses explicitBaseline over per-cluster baseline', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 90, baseline: 80, status: 'pass' },
+    ];
+    const result = aggregateResiliencyScores(scores, 70);
+    expect(result.baseline).toBe(70);
+  });
+
+  it('falls back to first cluster baseline when no explicit baseline', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 90, baseline: 75, status: 'pass' },
+      { clusterName: 'b', calculated: 80, baseline: 80, status: 'pass' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.baseline).toBe(75);
+  });
+
+  it('builds a per-cluster message', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'cluster-1', calculated: 90, baseline: 80, status: 'pass' },
+      { clusterName: 'cluster-2', calculated: 70, baseline: 80, status: 'fail' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.message).toBe('cluster-1: 90, cluster-2: 70');
+  });
+
+  it('computes correct average across clusters', () => {
+    const scores: GraphClusterScore[] = [
+      { clusterName: 'a', calculated: 100, baseline: 80, status: 'pass' },
+      { clusterName: 'b', calculated: 80, baseline: 80, status: 'pass' },
+      { clusterName: 'c', calculated: 60, baseline: 80, status: 'fail' },
+    ];
+    const result = aggregateResiliencyScores(scores);
+    expect(result.calculated).toBe(80);
   });
 });

--- a/src/utils/resiliency.ts
+++ b/src/utils/resiliency.ts
@@ -1,4 +1,5 @@
 import type { ClusterResiliencyScore, GraphClusterScore } from '../types/api';
+import type { ResiliencyScoreResponse } from '../types/api';
 
 /**
  * 5-level color gradient based on score/baseline ratio.
@@ -44,4 +45,29 @@ export function allClustersPassed(scores: GraphClusterScore[]): boolean {
 export function calculateNodeScoreAverage(scores: ClusterResiliencyScore[]): number {
   if (!scores || scores.length === 0) return 0;
   return scores.reduce((sum, cs) => sum + cs.score, 0) / scores.length;
+}
+
+export function aggregateResiliencyScores(
+  scores: GraphClusterScore[],
+  explicitBaseline?: number,
+): ResiliencyScoreResponse {
+  const avg = scores.reduce((sum, s) => sum + s.calculated, 0) / scores.length;
+  const baseline = explicitBaseline ?? scores[0]?.baseline;
+  const hasFail = scores.some(s => s.status === 'fail');
+  const hasNoBaseline =
+    baseline == null ||
+    baseline <= 0 ||
+    scores.some(s => s.status === 'no-baseline');
+
+  let status: ResiliencyScoreResponse['status'];
+  if (hasFail) status = 'fail';
+  else if (hasNoBaseline) status = 'no-baseline';
+  else status = 'pass';
+
+  return {
+    calculated: avg,
+    baseline,
+    status,
+    message: scores.map(s => `${s.clusterName}: ${s.calculated}`).join(', '),
+  };
 }


### PR DESCRIPTION
Defer fetchRunDetails calls to accordion expand instead of page load, reducing initial API calls. 
Fix resiliency score showing N/A by mapping the API's resiliencyScores (plural/per-cluster) to the UI's resiliencyScore (singular/aggregated). Add merge logic in reducers to prevent WS race conditions from wiping resiliency data.