### PR TITLE
fix(poller): add terminal phase guard and remove REST polling

### DIFF
--- a/src/hooks/__tests__/useScenarioRunsPoller.integration.test.tsx
+++ b/src/hooks/__tests__/useScenarioRunsPoller.integration.test.tsx
@@ -210,6 +210,42 @@ describe('useScenarioRunsPoller handleMessage integration', () => {
     );
   });
 
+  it('resets terminal guard after delete so re-created run can fetch again', async () => {
+    vi.mocked(operatorApi.getScenarioRunStatus).mockResolvedValue({
+      scenarioRunName: 'run-001', phase: 'Succeeded', totalTargets: 2,
+      successfulJobs: 2, failedJobs: 0, runningJobs: 0,
+      clusterJobs: [{ providerName: 'krkn', clusterName: 'c1', jobId: 'j1', podName: 'p1', phase: 'Succeeded', startTime: '' }],
+    });
+
+    mockScenarioRuns = [makeRunState({ phase: 'Running' })];
+    renderHook(() => useScenarioRunsPoller());
+
+    // Terminal transition → triggers REST fetch
+    sendWsMessage({
+      resource: 'run', id: 'run-001', event: 'updated',
+      data: { scenarioRunName: 'run-001', phase: 'Succeeded', totalTargets: 2, successfulJobs: 2, failedJobs: 0, runningJobs: 0, clusterJobs: [] },
+    });
+    await vi.waitFor(() => {
+      expect(operatorApi.getScenarioRunStatus).toHaveBeenCalledTimes(1);
+    });
+
+    // Delete clears the guard
+    sendWsMessage({ resource: 'run', id: 'run-001', event: 'deleted', data: {} });
+
+    // Re-create with same name → terminal transition should fire again
+    mockScenarioRuns = [makeRunState({ phase: 'Running', scenarioRunName: 'run-001' })];
+    vi.mocked(operatorApi.getScenarioRunStatus).mockClear();
+
+    sendWsMessage({
+      resource: 'run', id: 'run-001', event: 'updated',
+      data: { scenarioRunName: 'run-001', phase: 'Failed', totalTargets: 2, successfulJobs: 0, failedJobs: 2, runningJobs: 0, clusterJobs: [] },
+    });
+
+    await vi.waitFor(() => {
+      expect(operatorApi.getScenarioRunStatus).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('ignores messages for other resources', () => {
     renderHook(() => useScenarioRunsPoller());
 

--- a/src/hooks/__tests__/useScenarioRunsPoller.integration.test.tsx
+++ b/src/hooks/__tests__/useScenarioRunsPoller.integration.test.tsx
@@ -1,0 +1,225 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ServerMessage } from '../../types/websocket';
+import type { ScenarioRunState, ScenarioRunStatusResponse } from '../../types/api';
+
+const mockDispatch = vi.fn();
+let mockScenarioRuns: ScenarioRunState[] = [];
+
+vi.mock('../../context/AppContext', () => ({
+  useAppContext: () => ({
+    state: { scenarioRuns: mockScenarioRuns, expandedRunIds: new Set<string>() },
+    dispatch: mockDispatch,
+  }),
+}));
+
+let capturedHandler: ((msg: ServerMessage) => void) | null = null;
+const mockConnectionState = { value: 'disconnected' as string };
+
+vi.mock('../useWebSocket', () => ({
+  useWebSocket: (_id: string, _url: string, handler: (msg: ServerMessage) => void) => {
+    capturedHandler = handler;
+    return { connectionState: mockConnectionState.value, subscribe: vi.fn(), unsubscribe: vi.fn() };
+  },
+}));
+
+vi.mock('../../services/operatorApi');
+vi.mock('../../services/websocketService', () => ({
+  websocketService: {
+    buildResourceUrl: vi.fn(() => 'ws://localhost/api/v2/ws/runs'),
+    subscribe: vi.fn(),
+  },
+}));
+
+import { operatorApi } from '../../services/operatorApi';
+import { useScenarioRunsPoller } from '../useScenarioRunsPoller';
+
+function makeRunState(overrides: Partial<ScenarioRunState> = {}): ScenarioRunState {
+  return {
+    scenarioRunName: 'run-001',
+    scenarioName: 'test-scenario',
+    phase: 'Running',
+    totalTargets: 2,
+    successfulJobs: 0,
+    failedJobs: 0,
+    runningJobs: 2,
+    clusterJobs: [],
+    createdAt: '2025-06-15T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function sendWsMessage(msg: ServerMessage) {
+  act(() => { capturedHandler?.(msg); });
+}
+
+describe('useScenarioRunsPoller handleMessage integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedHandler = null;
+    mockScenarioRuns = [];
+    mockConnectionState.value = 'connected';
+  });
+
+  it('dispatches UPDATE_SCENARIO_RUN on terminal transition', () => {
+    mockScenarioRuns = [makeRunState({ phase: 'Running' })];
+    renderHook(() => useScenarioRunsPoller());
+
+    sendWsMessage({
+      resource: 'run',
+      id: 'run-001',
+      event: 'updated',
+      data: { scenarioRunName: 'run-001', phase: 'Succeeded', totalTargets: 2, successfulJobs: 2, failedJobs: 0, runningJobs: 0, clusterJobs: [] },
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'UPDATE_SCENARIO_RUN' }),
+    );
+  });
+
+  it('triggers fetchRunDetails on terminal transition when WS has no clusterJobs', async () => {
+    const restResponse: ScenarioRunStatusResponse = {
+      scenarioRunName: 'run-001',
+      phase: 'Running',
+      totalTargets: 2,
+      successfulJobs: 2,
+      failedJobs: 0,
+      runningJobs: 0,
+      clusterJobs: [{ providerName: 'krkn', clusterName: 'c1', jobId: 'j1', podName: 'p1', phase: 'Succeeded', startTime: '' }],
+    };
+    vi.mocked(operatorApi.getScenarioRunStatus).mockResolvedValue(restResponse);
+
+    mockScenarioRuns = [makeRunState({ phase: 'Running' })];
+    renderHook(() => useScenarioRunsPoller());
+
+    sendWsMessage({
+      resource: 'run',
+      id: 'run-001',
+      event: 'updated',
+      data: { scenarioRunName: 'run-001', phase: 'Succeeded', totalTargets: 2, successfulJobs: 2, failedJobs: 0, runningJobs: 0, clusterJobs: [] },
+    });
+
+    await vi.waitFor(() => {
+      expect(operatorApi.getScenarioRunStatus).toHaveBeenCalledWith('run-001');
+    });
+  });
+
+  it('skips fetchRunDetails on terminal transition when WS already includes clusterJobs', () => {
+    mockScenarioRuns = [makeRunState({ phase: 'Running' })];
+    renderHook(() => useScenarioRunsPoller());
+
+    sendWsMessage({
+      resource: 'run',
+      id: 'run-001',
+      event: 'updated',
+      data: {
+        scenarioRunName: 'run-001', phase: 'Succeeded', totalTargets: 2, successfulJobs: 2, failedJobs: 0, runningJobs: 0,
+        clusterJobs: [{ providerName: 'krkn', clusterName: 'c1', jobId: 'j1', podName: 'p1', phase: 'Succeeded', startTime: '' }],
+      },
+    });
+
+    expect(operatorApi.getScenarioRunStatus).not.toHaveBeenCalled();
+  });
+
+  it('does not trigger duplicate REST calls on repeated terminal WS messages', () => {
+    mockScenarioRuns = [makeRunState({ phase: 'Running' })];
+    renderHook(() => useScenarioRunsPoller());
+
+    const terminalMsg: ServerMessage = {
+      resource: 'run',
+      id: 'run-001',
+      event: 'updated',
+      data: { scenarioRunName: 'run-001', phase: 'Succeeded', totalTargets: 2, successfulJobs: 2, failedJobs: 0, runningJobs: 0, clusterJobs: [] },
+    };
+
+    sendWsMessage(terminalMsg);
+    sendWsMessage(terminalMsg);
+    sendWsMessage(terminalMsg);
+
+    // fetchRunDetails has its own guard, plus terminalFetchDoneRef prevents re-entry
+    const callCount = vi.mocked(operatorApi.getScenarioRunStatus).mock.calls.length;
+    expect(callCount).toBeLessThanOrEqual(1);
+  });
+
+  it('preserves terminal phase when REST returns stale non-terminal data', async () => {
+    const staleRest: ScenarioRunStatusResponse = {
+      scenarioRunName: 'run-001',
+      phase: 'Running',
+      totalTargets: 2,
+      successfulJobs: 1,
+      failedJobs: 0,
+      runningJobs: 1,
+      clusterJobs: [{ providerName: 'krkn', clusterName: 'c1', jobId: 'j1', podName: 'p1', phase: 'Running', startTime: '' }],
+    };
+    vi.mocked(operatorApi.getScenarioRunStatus).mockResolvedValue(staleRest);
+
+    mockScenarioRuns = [makeRunState({ phase: 'Running' })];
+    renderHook(() => useScenarioRunsPoller());
+
+    sendWsMessage({
+      resource: 'run',
+      id: 'run-001',
+      event: 'updated',
+      data: { scenarioRunName: 'run-001', phase: 'Succeeded', totalTargets: 2, successfulJobs: 2, failedJobs: 0, runningJobs: 0, clusterJobs: [] },
+    });
+
+    await vi.waitFor(() => {
+      expect(operatorApi.getScenarioRunStatus).toHaveBeenCalled();
+    });
+
+    const restDispatch = mockDispatch.mock.calls.find(
+      ([action]) => action.type === 'UPDATE_SCENARIO_RUN' && action.payload.run.clusterJobs.length > 0,
+    );
+    expect(restDispatch).toBeDefined();
+    // Terminal phase from WS is preserved, not overwritten by stale REST
+    expect(restDispatch![0].payload.run.phase).toBe('Succeeded');
+  });
+
+  it('adds new run on created event', () => {
+    mockScenarioRuns = [];
+    renderHook(() => useScenarioRunsPoller());
+
+    sendWsMessage({
+      resource: 'run',
+      id: 'new-run-001',
+      event: 'created',
+      data: { scenarioRunName: 'new-run-001', phase: 'Pending', totalTargets: 1, successfulJobs: 0, failedJobs: 0, runningJobs: 0, clusterJobs: [] },
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ADD_SCENARIO_RUN',
+        payload: expect.objectContaining({ run: expect.objectContaining({ scenarioRunName: 'new-run-001' }) }),
+      }),
+    );
+  });
+
+  it('removes run on deleted event', () => {
+    mockScenarioRuns = [makeRunState()];
+    renderHook(() => useScenarioRunsPoller());
+
+    sendWsMessage({
+      resource: 'run',
+      id: 'run-001',
+      event: 'deleted',
+      data: {},
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'LOAD_SCENARIO_RUNS_SUCCESS' }),
+    );
+  });
+
+  it('ignores messages for other resources', () => {
+    renderHook(() => useScenarioRunsPoller());
+
+    sendWsMessage({
+      resource: 'graph-run',
+      id: 'gr-001',
+      event: 'updated',
+      data: {},
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useScenarioRunsPoller.test.ts
+++ b/src/hooks/__tests__/useScenarioRunsPoller.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import type { ScenarioRunStatusResponse } from '../../types/api';
+import type { ScenarioRunStatusResponse, ScenarioRunState } from '../../types/api';
+import { TERMINAL_PHASES, hasChanges } from '../useScenarioRunsPoller';
 
 /**
  * Replicates the timestamp mapping logic from useScenarioRunsPoller.ts (line 77):
@@ -75,5 +76,143 @@ describe('useScenarioRunsPoller timestamp mapping', () => {
       ],
     });
     expect(mapCreatedAt(run)).toBe('2025-06-15T10:00:00Z');
+  });
+});
+
+function makeRunState(overrides: Partial<ScenarioRunState> = {}): ScenarioRunState {
+  return {
+    scenarioRunName: 'test-run-abc12345',
+    scenarioName: 'test-scenario',
+    phase: 'Running',
+    totalTargets: 1,
+    successfulJobs: 0,
+    failedJobs: 0,
+    runningJobs: 1,
+    clusterJobs: [],
+    createdAt: '2025-06-15T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('TERMINAL_PHASES', () => {
+  it('includes Succeeded, Failed, and PartiallyFailed', () => {
+    expect(TERMINAL_PHASES).toContain('Succeeded');
+    expect(TERMINAL_PHASES).toContain('Failed');
+    expect(TERMINAL_PHASES).toContain('PartiallyFailed');
+  });
+
+  it('does not include active phases', () => {
+    expect(TERMINAL_PHASES).not.toContain('Running');
+    expect(TERMINAL_PHASES).not.toContain('Pending');
+    expect(TERMINAL_PHASES).not.toContain('');
+  });
+
+  it.each([
+    ['Running', 'Succeeded', true],
+    ['Running', 'Failed', true],
+    ['Running', 'PartiallyFailed', true],
+    ['Pending', 'Succeeded', true],
+    ['Succeeded', 'Failed', false],
+    ['Failed', 'Succeeded', false],
+    ['Running', 'Running', false],
+    ['Running', 'Pending', false],
+  ])('transition from %s to %s is terminal transition: %s', (from, to, expected) => {
+    const result = !TERMINAL_PHASES.includes(from) && TERMINAL_PHASES.includes(to);
+    expect(result).toBe(expected);
+  });
+});
+
+describe('hasChanges', () => {
+  it('returns false for identical states', () => {
+    const run = makeRunState();
+    expect(hasChanges(run, { ...run })).toBe(false);
+  });
+
+  it('detects phase change', () => {
+    const prev = makeRunState({ phase: 'Running' });
+    const next = makeRunState({ phase: 'Succeeded' });
+    expect(hasChanges(prev, next)).toBe(true);
+  });
+
+  it('detects totalTargets change', () => {
+    const prev = makeRunState({ totalTargets: 1 });
+    const next = makeRunState({ totalTargets: 3 });
+    expect(hasChanges(prev, next)).toBe(true);
+  });
+
+  it('detects runningJobs change', () => {
+    const prev = makeRunState({ runningJobs: 1 });
+    const next = makeRunState({ runningJobs: 0 });
+    expect(hasChanges(prev, next)).toBe(true);
+  });
+
+  it('detects successfulJobs change', () => {
+    const prev = makeRunState({ successfulJobs: 0 });
+    const next = makeRunState({ successfulJobs: 1 });
+    expect(hasChanges(prev, next)).toBe(true);
+  });
+
+  it('detects failedJobs change', () => {
+    const prev = makeRunState({ failedJobs: 0 });
+    const next = makeRunState({ failedJobs: 1 });
+    expect(hasChanges(prev, next)).toBe(true);
+  });
+
+  it('detects customRunName change', () => {
+    const prev = makeRunState({ customRunName: undefined });
+    const next = makeRunState({ customRunName: 'new-name' });
+    expect(hasChanges(prev, next)).toBe(true);
+  });
+
+  it('detects clusterJobs length change', () => {
+    const prev = makeRunState({ clusterJobs: [] });
+    const next = makeRunState({
+      clusterJobs: [{
+        providerName: 'krkn-operator',
+        clusterName: 'c1',
+        jobId: 'j1',
+        podName: 'p1',
+        phase: 'Running',
+        startTime: '',
+      }],
+    });
+    expect(hasChanges(prev, next)).toBe(true);
+  });
+
+  it('detects clusterJob phase change', () => {
+    const job = {
+      providerName: 'krkn-operator',
+      clusterName: 'c1',
+      jobId: 'j1',
+      podName: 'p1',
+      startTime: '',
+    };
+    const prev = makeRunState({ clusterJobs: [{ ...job, phase: 'Running' }] });
+    const next = makeRunState({ clusterJobs: [{ ...job, phase: 'Succeeded' }] });
+    expect(hasChanges(prev, next)).toBe(true);
+  });
+
+  it('detects missing clusterJob in next state', () => {
+    const prev = makeRunState({
+      clusterJobs: [{
+        providerName: 'krkn-operator',
+        clusterName: 'c1',
+        jobId: 'j1',
+        podName: 'p1',
+        phase: 'Running',
+        startTime: '',
+      }],
+    });
+    const next = makeRunState({
+      clusterJobs: [{
+        providerName: 'krkn-operator',
+        clusterName: 'c2',
+        jobId: 'j2',
+        podName: 'p2',
+        phase: 'Running',
+        startTime: '',
+      }],
+    });
+    expect(hasChanges(prev, next)).toBe(true);
   });
 });

--- a/src/hooks/useScenarioRunsPoller.ts
+++ b/src/hooks/useScenarioRunsPoller.ts
@@ -6,6 +6,8 @@ import { websocketService } from '../services/websocketService';
 import type { ServerMessage } from '../types/websocket';
 import type { ScenarioRunState, ScenarioRunStatusResponse } from '../types/api';
 
+export const TERMINAL_PHASES = ['Succeeded', 'Failed', 'PartiallyFailed'];
+
 /**
  * Hook to receive real-time scenario run updates via WebSocket.
  * Initial list+details fetched once via REST on first connect.
@@ -131,6 +133,14 @@ export function useScenarioRunsPoller() {
         if (hasChanges(existing, updatedState)) {
           dispatch({ type: 'UPDATE_SCENARIO_RUN', payload: { run: updatedState } });
         }
+
+        // On terminal phase transition, force one final detail fetch for clusterJobs
+        const isTerminalTransition =
+          !TERMINAL_PHASES.includes(existing.phase) && TERMINAL_PHASES.includes(data.phase);
+        if (isTerminalTransition) {
+          fetchedDetailsRef.current.delete(runName);
+          fetchRunDetails(runName, updatedState);
+        }
       } else {
         dispatch({ type: 'ADD_SCENARIO_RUN', payload: { run: updatedState } });
       }
@@ -158,31 +168,9 @@ export function useScenarioRunsPoller() {
     }
   }, [connectionState, fetchInitialScenarioRuns]);
 
-  // Periodically re-fetch details for expanded runs that are still active.
-  // Keeps clusterJob phases up-to-date until the per-run detail WebSocket is implemented.
-  useEffect(() => {
-    if (connectionState !== 'connected') return;
-
-    const intervalId = setInterval(() => {
-      const expandedIds = state.expandedRunIds;
-      const runs = scenarioRunsRef.current;
-
-      for (const runName of expandedIds) {
-        const run = runs.find(r => r.scenarioRunName === runName);
-        if (!run) continue;
-        if (['Succeeded', 'Failed', 'PartiallyFailed'].includes(run.phase)) continue;
-
-        fetchedDetailsRef.current.delete(runName);
-        fetchRunDetails(runName, run);
-      }
-    }, 5000);
-
-    return () => clearInterval(intervalId);
-  }, [connectionState, state.expandedRunIds, fetchRunDetails]);
-
 }
 
-function hasChanges(prev: ScenarioRunState, next: ScenarioRunState): boolean {
+export function hasChanges(prev: ScenarioRunState, next: ScenarioRunState): boolean {
   if (prev.phase !== next.phase) return true;
   if (prev.totalTargets !== next.totalTargets) return true;
   if (prev.runningJobs !== next.runningJobs) return true;

--- a/src/hooks/useScenarioRunsPoller.ts
+++ b/src/hooks/useScenarioRunsPoller.ts
@@ -176,7 +176,18 @@ export function useScenarioRunsPoller() {
 
 }
 
-/** Shallow diff of the fields that affect UI rendering; true when a dispatch is needed. */
+/**
+ * Shallow diff of the fields that affect UI rendering; true when a dispatch is needed.
+ *
+ * @example
+ * ```ts
+ * const prev: ScenarioRunState = { phase: 'Running', runningJobs: 2, ... };
+ * const next: ScenarioRunState = { phase: 'Succeeded', runningJobs: 0, ... };
+ * if (hasChanges(prev, next)) {
+ *   dispatch({ type: 'UPDATE_SCENARIO_RUN', payload: { run: next } });
+ * }
+ * ```
+ */
 export function hasChanges(prev: ScenarioRunState, next: ScenarioRunState): boolean {
   if (prev.phase !== next.phase) return true;
   if (prev.totalTargets !== next.totalTargets) return true;

--- a/src/hooks/useScenarioRunsPoller.ts
+++ b/src/hooks/useScenarioRunsPoller.ts
@@ -21,6 +21,7 @@ export function useScenarioRunsPoller() {
 
   const initialFetchDoneRef = useRef(false);
   const fetchedDetailsRef = useRef<Set<string>>(new Set());
+  const terminalFetchDoneRef = useRef<Set<string>>(new Set());
 
   const fetchRunDetails = useCallback(async (runName: string, base: ScenarioRunState) => {
     if (fetchedDetailsRef.current.has(runName)) return;
@@ -33,23 +34,26 @@ export function useScenarioRunsPoller() {
         return;
       }
 
+      const preserveTerminal = TERMINAL_PHASES.includes(base.phase);
       dispatch({
         type: 'UPDATE_SCENARIO_RUN',
         payload: {
-          run: {
-            ...base,
-            phase: details.phase,
-            totalTargets: details.totalTargets,
-            successfulJobs: details.successfulJobs,
-            failedJobs: details.failedJobs,
-            runningJobs: details.runningJobs,
-            clusterJobs: details.clusterJobs,
-            ownerUserId: details.ownerUserId || base.ownerUserId,
-            registryName: details.registryName || base.registryName,
-            graphRunName: details.graphRunName || base.graphRunName,
-            graphNodeId: details.graphNodeId || base.graphNodeId,
-            customRunName: details.customRunName || base.customRunName,
-          },
+          run: preserveTerminal
+            ? { ...base, clusterJobs: details.clusterJobs }
+            : {
+                ...base,
+                phase: details.phase,
+                totalTargets: details.totalTargets,
+                successfulJobs: details.successfulJobs,
+                failedJobs: details.failedJobs,
+                runningJobs: details.runningJobs,
+                clusterJobs: details.clusterJobs,
+                ownerUserId: details.ownerUserId || base.ownerUserId,
+                registryName: details.registryName || base.registryName,
+                graphRunName: details.graphRunName || base.graphRunName,
+                graphNodeId: details.graphNodeId || base.graphNodeId,
+                customRunName: details.customRunName || base.customRunName,
+              },
         },
       });
     } catch {
@@ -134,10 +138,11 @@ export function useScenarioRunsPoller() {
           dispatch({ type: 'UPDATE_SCENARIO_RUN', payload: { run: updatedState } });
         }
 
-        // On terminal phase transition, force one final detail fetch for clusterJobs
+        // On terminal phase transition without WS clusterJobs, fetch final details once
         const isTerminalTransition =
           !TERMINAL_PHASES.includes(existing.phase) && TERMINAL_PHASES.includes(data.phase);
-        if (isTerminalTransition) {
+        if (isTerminalTransition && !hasWsJobs && !terminalFetchDoneRef.current.has(runName)) {
+          terminalFetchDoneRef.current.add(runName);
           fetchedDetailsRef.current.delete(runName);
           fetchRunDetails(runName, updatedState);
         }
@@ -151,6 +156,7 @@ export function useScenarioRunsPoller() {
       }
     } else if (message.event === 'deleted') {
       fetchedDetailsRef.current.delete(runName);
+      terminalFetchDoneRef.current.delete(runName);
       dispatch({
         type: 'LOAD_SCENARIO_RUNS_SUCCESS',
         payload: { runs: scenarioRunsRef.current.filter(r => r.scenarioRunName !== runName) },
@@ -170,6 +176,7 @@ export function useScenarioRunsPoller() {
 
 }
 
+/** Shallow diff of the fields that affect UI rendering; true when a dispatch is needed. */
 export function hasChanges(prev: ScenarioRunState, next: ScenarioRunState): boolean {
   if (prev.phase !== next.phase) return true;
   if (prev.totalTargets !== next.totalTargets) return true;


### PR DESCRIPTION
## Summary
- **Terminal phase guard**: When a WebSocket update transitions a run from an active phase (Running/Pending) to a terminal phase (Succeeded/Failed/PartiallyFailed), triggers one final `fetchRunDetails` call to ensure clusterJobs reflect the final state — defense-in-depth in case the WS message is missed.
- **Remove REST polling**: The 5s `setInterval` polling loop that re-fetched clusterJobs for expanded runs is no longer needed since the operator now includes ClusterJobs in the WS broadcast. The `handleMessage` callback handles clusterJobs in real-time via the existing `hasWsJobs` check.
- **Tests**: Added 20 new tests covering `TERMINAL_PHASES` transition logic and `hasChanges` detection across all tracked fields (phase, targets, jobs, clusterJobs).

## Test plan
- [x] All 785 existing tests pass
- [x] 20 new tests for terminal phase transitions and `hasChanges`
- [x] TypeScript compiles with no errors
- [ ] Verify in browser: run a scenario, confirm clusterJobs appear on completion without polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)