### PR TITLE
feat(pagination): add WebSocket pagination types, unified jobs API, and useJobs hook

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,9 @@ export const config = {
   pollInterval: parseInt(import.meta.env.VITE_POLL_INTERVAL || '3000'), // 3 seconds
   pollTimeout: parseInt(import.meta.env.VITE_POLL_TIMEOUT || '60000'),  // 60 seconds
 
+  // V2 REST API base URL
+  apiV2BaseUrl: import.meta.env.VITE_API_V2_URL || '/api/v2',
+
   // WebSocket base URL for v2 API
   wsBaseUrl: import.meta.env.VITE_WS_URL || '/api/v2/ws',
 

--- a/src/hooks/__tests__/useJobs.test.tsx
+++ b/src/hooks/__tests__/useJobs.test.tsx
@@ -1,0 +1,226 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ServerMessage } from '../../types/websocket';
+import type { UnifiedJobsResponse } from '../../types/api';
+
+vi.mock('../../services/operatorApi');
+
+let capturedHandler: ((msg: ServerMessage) => void) | null = null;
+const mockConnectionState = { value: 'disconnected' as string };
+const mockSubscribe = vi.fn();
+
+vi.mock('../useWebSocket', () => ({
+  useWebSocket: (_id: string, _url: string, handler: (msg: ServerMessage) => void) => {
+    capturedHandler = handler;
+    return { connectionState: mockConnectionState.value, subscribe: mockSubscribe, unsubscribe: vi.fn() };
+  },
+}));
+
+vi.mock('../../services/websocketService', () => ({
+  websocketService: {
+    buildResourceUrl: vi.fn(() => 'ws://localhost/api/v2/ws/runs'),
+    subscribe: vi.fn(),
+  },
+}));
+
+import { operatorApi } from '../../services/operatorApi';
+import { websocketService } from '../../services/websocketService';
+import { useJobs } from '../useJobs';
+
+const mockJobsResponse: UnifiedJobsResponse = {
+  jobs: [
+    { type: 'scenarioRun', name: 'run-001', createdAt: '2026-08-01T10:00:00Z' },
+    { type: 'graphRun', name: 'graph-001', createdAt: '2026-08-01T09:00:00Z' },
+  ],
+  pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+};
+
+function sendWsMessage(msg: ServerMessage) {
+  act(() => { capturedHandler?.(msg); });
+}
+
+describe('useJobs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedHandler = null;
+    mockConnectionState.value = 'connected';
+    vi.mocked(operatorApi.listUnifiedJobs).mockResolvedValue(mockJobsResponse);
+  });
+
+  it('fetches initial jobs on connect', async () => {
+    renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(1, 20);
+    });
+  });
+
+  it('subscribes to WS with page and limit', async () => {
+    renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(websocketService.subscribe).toHaveBeenCalledWith('jobs', 'jobs', undefined, 1, 20);
+    });
+  });
+
+  it('exposes jobs and pagination from REST response', async () => {
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(result.current.jobs).toHaveLength(2);
+    });
+
+    expect(result.current.jobs[0].name).toBe('run-001');
+    expect(result.current.pagination.total).toBe(2);
+    expect(result.current.pagination.totalPages).toBe(1);
+  });
+
+  it('updates jobs on WS snapshot event', async () => {
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(result.current.jobs).toHaveLength(2);
+    });
+
+    sendWsMessage({
+      resource: 'jobs',
+      id: '',
+      event: 'snapshot',
+      data: {
+        jobs: [
+          { type: 'scenarioRun', name: 'run-002', createdAt: '2026-08-02T10:00:00Z' },
+        ],
+      },
+      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    });
+
+    expect(result.current.jobs).toHaveLength(1);
+    expect(result.current.jobs[0].name).toBe('run-002');
+    expect(result.current.pagination.total).toBe(1);
+  });
+
+  it('re-fetches on WS created event', async () => {
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(result.current.jobs).toHaveLength(2);
+    });
+
+    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
+
+    sendWsMessage({
+      resource: 'jobs',
+      id: 'run-003',
+      event: 'created',
+      data: {},
+    });
+
+    await waitFor(() => {
+      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(1, 20);
+    });
+  });
+
+  it('re-fetches on WS deleted event', async () => {
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(result.current.jobs).toHaveLength(2);
+    });
+
+    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
+
+    sendWsMessage({
+      resource: 'jobs',
+      id: 'run-001',
+      event: 'deleted',
+      data: {},
+    });
+
+    await waitFor(() => {
+      expect(operatorApi.listUnifiedJobs).toHaveBeenCalled();
+    });
+  });
+
+  it('ignores messages for other resources', async () => {
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(result.current.jobs).toHaveLength(2);
+    });
+
+    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
+
+    sendWsMessage({
+      resource: 'run',
+      id: 'run-001',
+      event: 'updated',
+      data: {},
+    });
+
+    expect(operatorApi.listUnifiedJobs).not.toHaveBeenCalled();
+  });
+
+  it('re-subscribes when page changes', async () => {
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(result.current.jobs).toHaveLength(2);
+    });
+
+    vi.mocked(websocketService.subscribe).mockClear();
+    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
+
+    act(() => { result.current.setPage(2); });
+
+    await waitFor(() => {
+      expect(websocketService.subscribe).toHaveBeenCalledWith('jobs', 'jobs', undefined, 2, 20);
+      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(2, 20);
+    });
+  });
+
+  it('re-subscribes when limit changes', async () => {
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(result.current.jobs).toHaveLength(2);
+    });
+
+    vi.mocked(websocketService.subscribe).mockClear();
+    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
+
+    act(() => { result.current.setLimit(50); });
+
+    await waitFor(() => {
+      expect(websocketService.subscribe).toHaveBeenCalledWith('jobs', 'jobs', undefined, 1, 50);
+      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(1, 50);
+    });
+  });
+
+  it('does not fetch when disconnected', () => {
+    mockConnectionState.value = 'disconnected';
+    renderHook(() => useJobs());
+
+    expect(operatorApi.listUnifiedJobs).not.toHaveBeenCalled();
+  });
+
+  it('sets isLoading during fetch', async () => {
+    let resolvePromise: (v: UnifiedJobsResponse) => void;
+    vi.mocked(operatorApi.listUnifiedJobs).mockImplementation(
+      () => new Promise(r => { resolvePromise = r; })
+    );
+
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    await act(async () => {
+      resolvePromise!(mockJobsResponse);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+});

--- a/src/hooks/__tests__/useWebSocket.test.tsx
+++ b/src/hooks/__tests__/useWebSocket.test.tsx
@@ -125,13 +125,25 @@ describe('useWebSocket', () => {
       result.current.subscribe('run', ['run-1']);
     });
 
-    expect(mockSubscribe).toHaveBeenCalledWith('test-callbacks', 'run', ['run-1']);
+    expect(mockSubscribe).toHaveBeenCalledWith('test-callbacks', 'run', ['run-1'], undefined, undefined);
 
     act(() => {
       result.current.unsubscribe('run', ['run-1']);
     });
 
     expect(mockUnsubscribe).toHaveBeenCalledWith('test-callbacks', 'run', ['run-1']);
+  });
+
+  it('should forward pagination params to subscribe', () => {
+    const { result } = renderHook(() =>
+      useWebSocket('test-pagination', 'ws://localhost/test')
+    );
+
+    act(() => {
+      result.current.subscribe('jobs', undefined, 2, 20);
+    });
+
+    expect(mockSubscribe).toHaveBeenCalledWith('test-pagination', 'jobs', undefined, 2, 20);
   });
 
   it('should clean up handlers on unmount in subscription mode', () => {

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -33,22 +33,31 @@ export function useJobs(): UseJobsReturn {
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
   const [isLoading, setIsLoading] = useState(false);
 
-  const initialFetchDoneRef = useRef(false);
   const pageRef = useRef(page);
   const limitRef = useRef(limit);
   pageRef.current = page;
   limitRef.current = limit;
 
+  const requestIdRef = useRef(0);
+  const lastFetchedRef = useRef<string | null>(null);
+
   const fetchJobs = useCallback(async (p: number, l: number) => {
+    const requestId = ++requestIdRef.current;
     setIsLoading(true);
     try {
       const data: UnifiedJobsResponse = await operatorApi.listUnifiedJobs(p, l);
+      if (requestId !== requestIdRef.current) return;
       setJobs(data.jobs);
+      if (data.pagination.page !== p) setPage(data.pagination.page);
+      if (data.pagination.limit !== l) setLimit(data.pagination.limit);
       setPagination(data.pagination);
-    } catch {
-      // Keep existing state on error
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      console.error('Failed to fetch jobs:', err);
     } finally {
-      setIsLoading(false);
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 
@@ -64,7 +73,6 @@ export function useJobs(): UseJobsReturn {
         setPagination(message.pagination);
       }
     } else if (message.event === 'created' || message.event === 'updated') {
-      // Individual item update — re-fetch current page for consistency
       fetchJobs(pageRef.current, limitRef.current);
     } else if (message.event === 'deleted') {
       fetchJobs(pageRef.current, limitRef.current);
@@ -74,27 +82,20 @@ export function useJobs(): UseJobsReturn {
   const wsUrl = websocketService.buildResourceUrl('runs');
   const { connectionState } = useWebSocket('jobs', wsUrl, handleMessage);
 
-  // Initial fetch + subscribe on connect
+  // Fetch + subscribe on connect and when page/limit changes
   useEffect(() => {
     if (connectionState !== 'connected') {
-      initialFetchDoneRef.current = false;
+      lastFetchedRef.current = null;
       return;
     }
-    if (initialFetchDoneRef.current) return;
-    initialFetchDoneRef.current = true;
+
+    const key = `${page}:${limit}`;
+    if (lastFetchedRef.current === key) return;
+    lastFetchedRef.current = key;
 
     fetchJobs(page, limit);
     websocketService.subscribe('jobs', 'jobs', undefined, page, limit);
   }, [connectionState, page, limit, fetchJobs]);
-
-  // Re-subscribe + re-fetch when page or limit changes
-  useEffect(() => {
-    if (connectionState !== 'connected') return;
-    if (!initialFetchDoneRef.current) return;
-
-    fetchJobs(page, limit);
-    websocketService.subscribe('jobs', 'jobs', undefined, page, limit);
-  }, [page, limit, connectionState, fetchJobs]);
 
   return { jobs, pagination, page, setPage, limit, setLimit, isLoading };
 }

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { operatorApi } from '../services/operatorApi';
+import { useWebSocket } from './useWebSocket';
+import { websocketService } from '../services/websocketService';
+import type { ServerMessage, PaginationMeta } from '../types/websocket';
+import type { UnifiedJobItem, UnifiedJobsResponse } from '../types/api';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+const EMPTY_PAGINATION: PaginationMeta = { page: 0, limit: 0, total: 0, totalPages: 0 };
+
+interface UseJobsReturn {
+  jobs: UnifiedJobItem[];
+  pagination: PaginationMeta;
+  page: number;
+  setPage: (page: number) => void;
+  limit: number;
+  setLimit: (limit: number) => void;
+  isLoading: boolean;
+}
+
+/**
+ * Hook providing a unified paginated jobs list via REST + WebSocket.
+ *
+ * On mount: fetches the initial page via REST.
+ * Subscribes to WS resource 'jobs' with page/limit for real-time snapshots.
+ * When page or limit changes, re-subscribes and re-fetches.
+ */
+export function useJobs(): UseJobsReturn {
+  const [jobs, setJobs] = useState<UnifiedJobItem[]>([]);
+  const [pagination, setPagination] = useState<PaginationMeta>(EMPTY_PAGINATION);
+  const [page, setPage] = useState(DEFAULT_PAGE);
+  const [limit, setLimit] = useState(DEFAULT_LIMIT);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const initialFetchDoneRef = useRef(false);
+  const pageRef = useRef(page);
+  const limitRef = useRef(limit);
+  pageRef.current = page;
+  limitRef.current = limit;
+
+  const fetchJobs = useCallback(async (p: number, l: number) => {
+    setIsLoading(true);
+    try {
+      const data: UnifiedJobsResponse = await operatorApi.listUnifiedJobs(p, l);
+      setJobs(data.jobs);
+      setPagination(data.pagination);
+    } catch {
+      // Keep existing state on error
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const handleMessage = useCallback((message: ServerMessage) => {
+    if (message.resource !== 'jobs') return;
+
+    if (message.event === 'snapshot') {
+      const data = message.data as { jobs?: UnifiedJobItem[] };
+      if (data.jobs) {
+        setJobs(data.jobs);
+      }
+      if (message.pagination) {
+        setPagination(message.pagination);
+      }
+    } else if (message.event === 'created' || message.event === 'updated') {
+      // Individual item update — re-fetch current page for consistency
+      fetchJobs(pageRef.current, limitRef.current);
+    } else if (message.event === 'deleted') {
+      fetchJobs(pageRef.current, limitRef.current);
+    }
+  }, [fetchJobs]);
+
+  const wsUrl = websocketService.buildResourceUrl('runs');
+  const { connectionState } = useWebSocket('jobs', wsUrl, handleMessage);
+
+  // Initial fetch + subscribe on connect
+  useEffect(() => {
+    if (connectionState !== 'connected') {
+      initialFetchDoneRef.current = false;
+      return;
+    }
+    if (initialFetchDoneRef.current) return;
+    initialFetchDoneRef.current = true;
+
+    fetchJobs(page, limit);
+    websocketService.subscribe('jobs', 'jobs', undefined, page, limit);
+  }, [connectionState, page, limit, fetchJobs]);
+
+  // Re-subscribe + re-fetch when page or limit changes
+  useEffect(() => {
+    if (connectionState !== 'connected') return;
+    if (!initialFetchDoneRef.current) return;
+
+    fetchJobs(page, limit);
+    websocketService.subscribe('jobs', 'jobs', undefined, page, limit);
+  }, [page, limit, connectionState, fetchJobs]);
+
+  return { jobs, pagination, page, setPage, limit, setLimit, isLoading };
+}

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -15,7 +15,7 @@ interface UseWebSocketOptions {
 
 interface UseWebSocketReturn {
   connectionState: ConnectionState;
-  subscribe: (resource: string, ids?: string[]) => void;
+  subscribe: (resource: string, ids?: string[], page?: number, limit?: number) => void;
   unsubscribe: (resource: string, ids?: string[]) => void;
 }
 
@@ -82,7 +82,7 @@ export function useWebSocket(
   }, [connectionId, url, disabled, subscriptionMode]);
 
   const subscribe = useCallback(
-    (resource: string, ids?: string[]) => websocketService.subscribe(connectionId, resource, ids),
+    (resource: string, ids?: string[], page?: number, limit?: number) => websocketService.subscribe(connectionId, resource, ids, page, limit),
     [connectionId],
   );
 

--- a/src/services/__tests__/operatorApi.jobs.test.ts
+++ b/src/services/__tests__/operatorApi.jobs.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { operatorApi } from '../operatorApi';
+import type { UnifiedJobsResponse } from '../../types/api';
+
+const mockFetch = vi.fn();
+
+describe('OperatorApi - listUnifiedJobs', () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+  });
+
+  const mockResponse: UnifiedJobsResponse = {
+    jobs: [
+      {
+        type: 'scenarioRun',
+        name: 'run-001',
+        createdAt: '2026-08-01T10:00:00Z',
+        scenarioRun: {
+          scenarioRunName: 'run-001',
+          phase: 'Running',
+          totalTargets: 2,
+          successfulJobs: 0,
+          failedJobs: 0,
+          runningJobs: 2,
+          clusterJobs: [],
+        },
+      },
+      {
+        type: 'graphRun',
+        name: 'graph-001',
+        createdAt: '2026-08-01T09:00:00Z',
+      },
+    ],
+    pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+  };
+
+  it('should fetch jobs with pagination params', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await operatorApi.listUnifiedJobs(1, 20);
+
+    expect(result).toEqual(mockResponse);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain('/api/v2/jobs');
+    expect(url).toContain('page=1');
+    expect(url).toContain('limit=20');
+  });
+
+  it('should fetch all jobs when no pagination params provided', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await operatorApi.listUnifiedJobs();
+
+    expect(result).toEqual(mockResponse);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toBe('/api/v2/jobs');
+    expect(url).not.toContain('page=');
+    expect(url).not.toContain('limit=');
+  });
+
+  it('should return empty response on 404', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({ message: 'Not Found' }),
+    });
+
+    const result = await operatorApi.listUnifiedJobs(1, 20);
+
+    expect(result.jobs).toEqual([]);
+    expect(result.pagination.total).toBe(0);
+  });
+
+  it('should throw on non-404 errors', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({ message: 'Database error' }),
+    });
+
+    await expect(operatorApi.listUnifiedJobs(1, 20)).rejects.toThrow('Database error');
+  });
+});

--- a/src/services/__tests__/websocketService.test.ts
+++ b/src/services/__tests__/websocketService.test.ts
@@ -292,6 +292,69 @@ describe('WebSocketService', () => {
       websocketService.disconnect('test-unsub');
     });
 
+    it('should send subscribe message with pagination params', () => {
+      websocketService.connect('test-sub-page', 'ws://localhost/test');
+      const ws = MockWebSocket.latest!;
+      ws.simulateOpen();
+
+      websocketService.subscribe('test-sub-page', 'jobs', undefined, 1, 20);
+
+      expect(ws.sent).toHaveLength(1);
+      expect(JSON.parse(ws.sent[0])).toEqual({
+        action: 'subscribe',
+        resource: 'jobs',
+        page: 1,
+        limit: 20,
+      });
+
+      websocketService.disconnect('test-sub-page');
+    });
+
+    it('should update existing subscription when page changes', () => {
+      websocketService.connect('test-sub-update', 'ws://localhost/test');
+      const ws = MockWebSocket.latest!;
+      ws.simulateOpen();
+
+      websocketService.subscribe('test-sub-update', 'jobs', undefined, 1, 20);
+      websocketService.subscribe('test-sub-update', 'jobs', undefined, 2, 20);
+
+      expect(ws.sent).toHaveLength(2);
+      expect(JSON.parse(ws.sent[1])).toEqual({
+        action: 'subscribe',
+        resource: 'jobs',
+        page: 2,
+        limit: 20,
+      });
+
+      websocketService.disconnect('test-sub-update');
+    });
+
+    it('should re-subscribe with pagination after reconnect', () => {
+      websocketService.connect('test-resub-page', 'ws://localhost/test', {
+        baseReconnectDelay: 100,
+      });
+      const ws1 = MockWebSocket.latest!;
+      ws1.simulateOpen();
+
+      websocketService.subscribe('test-resub-page', 'jobs', undefined, 3, 10);
+
+      ws1.simulateClose(1006);
+      vi.advanceTimersByTime(100);
+
+      const ws2 = MockWebSocket.latest!;
+      ws2.simulateOpen();
+
+      expect(ws2.sent).toHaveLength(1);
+      expect(JSON.parse(ws2.sent[0])).toEqual({
+        action: 'subscribe',
+        resource: 'jobs',
+        page: 3,
+        limit: 10,
+      });
+
+      websocketService.disconnect('test-resub-page');
+    });
+
     it('should re-subscribe after reconnect', () => {
       websocketService.connect('test-resub', 'ws://localhost/test', {
         baseReconnectDelay: 100,

--- a/src/services/operatorApi.ts
+++ b/src/services/operatorApi.ts
@@ -1,5 +1,5 @@
 import { config } from '../config';
-import { BaseApiClient } from '../utils/apiClient';
+import { BaseApiClient, authenticatedFetch } from '../utils/apiClient';
 import type {
   CreateTargetResponse,
   ClustersResponse,
@@ -29,7 +29,8 @@ import type {
   FileTypesListResponse,
   CreateFileTypeRequest,
   UpdateFileTypeRequest,
-  JobConfigResponse
+  JobConfigResponse,
+  UnifiedJobsResponse,
 } from '../types/api';
 
 class OperatorApiClient extends BaseApiClient {
@@ -593,6 +594,40 @@ class OperatorApiClient extends BaseApiClient {
     await this.fetchJson<void>(`/file-types/${encodeURIComponent(name)}`, {
       method: 'DELETE',
     });
+  }
+
+  /**
+   * GET /api/v2/jobs
+   * List unified jobs (scenario runs + graph runs) with optional pagination.
+   * When page/limit are omitted, all items are returned.
+   */
+  async listUnifiedJobs(page?: number, limit?: number): Promise<UnifiedJobsResponse> {
+    const params = new URLSearchParams();
+    if (page !== undefined) params.set('page', String(page));
+    if (limit !== undefined) params.set('limit', String(limit));
+    const query = params.toString();
+    const url = `${config.apiV2BaseUrl}/jobs${query ? `?${query}` : ''}`;
+
+    try {
+      const response = await authenticatedFetch(url);
+      if (!response.ok) {
+        if (response.status === 404) {
+          return { jobs: [], pagination: { page: 0, limit: 0, total: 0, totalPages: 0 } };
+        }
+        let message = `HTTP ${response.status}: ${response.statusText}`;
+        try {
+          const error = await response.json();
+          if (error.message) message = error.message;
+        } catch { /* use default message */ }
+        throw new Error(message);
+      }
+      return response.json();
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('404')) {
+        return { jobs: [], pagination: { page: 0, limit: 0, total: 0, totalPages: 0 } };
+      }
+      throw error;
+    }
   }
 }
 

--- a/src/services/websocketService.ts
+++ b/src/services/websocketService.ts
@@ -121,20 +121,22 @@ class WebSocketService {
    * Send a subscribe message over a subscription-mode connection.
    * Subscriptions are persisted and re-sent on reconnect.
    */
-  subscribe(connectionId: string, resource: string, ids?: string[]): void {
+  subscribe(connectionId: string, resource: string, ids?: string[], page?: number, limit?: number): void {
     const conn = this.connections.get(connectionId);
     if (!conn) return;
 
-    const sub: Subscription = { resource, ids };
-    const alreadySubscribed = conn.subscriptions.some(
+    const sub: Subscription = { resource, ids, page, limit };
+    const existingIdx = conn.subscriptions.findIndex(
       s => s.resource === resource && JSON.stringify(s.ids) === JSON.stringify(ids)
     );
-    if (!alreadySubscribed) {
+    if (existingIdx >= 0) {
+      conn.subscriptions[existingIdx] = sub;
+    } else {
       conn.subscriptions.push(sub);
     }
 
     if (conn.ws?.readyState === WebSocket.OPEN) {
-      this.sendClientMessage(conn, { action: 'subscribe', resource, ids });
+      this.sendClientMessage(conn, { action: 'subscribe', resource, ids, page, limit });
     }
   }
 
@@ -325,7 +327,7 @@ class WebSocketService {
   private resubscribeAll(conn: ManagedConnection): void {
     if (!conn.options.subscriptionMode) return;
     for (const sub of conn.subscriptions) {
-      this.sendClientMessage(conn, { action: 'subscribe', resource: sub.resource, ids: sub.ids });
+      this.sendClientMessage(conn, { action: 'subscribe', resource: sub.resource, ids: sub.ids, page: sub.page, limit: sub.limit });
     }
   }
 

--- a/src/services/websocketService.ts
+++ b/src/services/websocketService.ts
@@ -120,6 +120,24 @@ class WebSocketService {
   /**
    * Send a subscribe message over a subscription-mode connection.
    * Subscriptions are persisted and re-sent on reconnect.
+   *
+   * @param connectionId - The connection to subscribe on
+   * @param resource - The resource type to subscribe to (e.g. 'jobs', 'scenarioRuns')
+   * @param ids - Optional array of specific resource IDs to watch
+   * @param page - Optional page number for paginated snapshots
+   * @param limit - Optional page size for paginated snapshots
+   *
+   * @example
+   * ```ts
+   * // Subscribe to all jobs, paginated
+   * websocketService.subscribe('jobs', 'jobs', undefined, 1, 20);
+   *
+   * // Subscribe to specific scenario runs (no pagination)
+   * websocketService.subscribe('runs', 'scenarioRuns', ['run-abc', 'run-def']);
+   *
+   * // Re-subscribe with new page (replaces existing subscription for same resource)
+   * websocketService.subscribe('jobs', 'jobs', undefined, 2, 20);
+   * ```
    */
   subscribe(connectionId: string, resource: string, ids?: string[], page?: number, limit?: number): void {
     const conn = this.connections.get(connectionId);

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -954,6 +954,24 @@ export type RunItem =
   | (ScenarioRunState & { runType: 'scenario' })
   | (GraphRunState & { runType: 'graph' });
 
+// Re-export PaginationMeta from websocket types (single source of truth)
+export type { PaginationMeta } from './websocket';
+
+/** Server-side unified job item from GET /api/v2/jobs */
+export interface UnifiedJobItem {
+  type: 'scenarioRun' | 'graphRun';
+  name: string;
+  createdAt: string;
+  scenarioRun?: ScenarioRunStatusResponse;
+  graphRun?: GraphRunListItem;
+}
+
+/** Response from GET /api/v2/jobs */
+export interface UnifiedJobsResponse {
+  jobs: UnifiedJobItem[];
+  pagination: import('./websocket').PaginationMeta;
+}
+
 // Chaos Scenario Studio Types
 
 /**

--- a/src/types/websocket.ts
+++ b/src/types/websocket.ts
@@ -9,11 +9,21 @@
 // Connection state
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting' | 'error';
 
+// Pagination metadata (shared with REST API responses)
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+}
+
 // Client → Server messages (subscription pattern only)
 export interface SubscribeMessage {
   action: 'subscribe';
   resource: string;
   ids?: string[];
+  page?: number;
+  limit?: number;
 }
 
 export interface UnsubscribeMessage {
@@ -25,13 +35,14 @@ export interface UnsubscribeMessage {
 export type ClientMessage = SubscribeMessage | UnsubscribeMessage;
 
 // Server → Client messages (subscription pattern)
-export type ServerEventType = 'updated' | 'created' | 'deleted';
+export type ServerEventType = 'updated' | 'created' | 'deleted' | 'snapshot';
 
 export interface ServerMessage<T = unknown> {
   resource: string;
   id: string;
   event: ServerEventType;
   data: T;
+  pagination?: PaginationMeta;
 }
 
 // Event handlers
@@ -43,6 +54,8 @@ export type ConnectionStateHandler = (state: ConnectionState) => void;
 export interface Subscription {
   resource: string;
   ids?: string[];
+  page?: number;
+  limit?: number;
 }
 
 // Connection configuration


### PR DESCRIPTION
## Summary

- Extend WebSocket types with `page`/`limit` in `SubscribeMessage` and `Subscription`, add `PaginationMeta` to `ServerMessage`, and add `'snapshot'` event type
- Update `websocketService.subscribe()` to accept, persist, and replay page/limit params on reconnect — resubscribe replaces in-place instead of deduplicating
- Add `apiV2BaseUrl` config and `listUnifiedJobs()` API method for the unified `GET /api/v2/jobs` endpoint with server-side pagination
- Add `UnifiedJobItem`, `UnifiedJobsResponse` types matching the backend contract
- Create `useJobs` hook with REST initial fetch + WS real-time snapshots, exposing `page`/`setPage`/`limit`/`setLimit` for consumer pagination control
- 19 new tests across all layers (WS service, hook, API, useJobs integration)

## Test plan

- [x] All 813 tests pass across 58 test files
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] Manual: verify WS subscription messages include page/limit via browser DevTools
- [ ] Manual: integrate with JobsList page (Phase 2) and verify pagination controls work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)