### PR TITLE
feat(pagination): refactor JobsList to unified data model with pagination

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -205,7 +205,6 @@ function App() {
         return (
           <PageSection>
             <JobsList
-              scenarioRuns={state.scenarioRuns}
               expandedRunIds={state.expandedRunIds}
               expandedJobIds={state.expandedClusterJobs}
               onToggleRunAccordion={(scenarioRunName) =>
@@ -219,7 +218,6 @@ function App() {
               onCreateJob={handleCreateJob}
               onNavigateToStudio={handleNavigateToStudio}
               onRerunScenario={handleRerunScenario}
-              graphRuns={state.graphRuns}
               expandedGraphRunIds={state.expandedGraphRunIds}
               onToggleGraphRunAccordion={(graphRunName) =>
                 dispatch({ type: 'TOGGLE_GRAPH_RUN_ACCORDION', payload: { graphRunName } })

--- a/src/components/JobStatsSummary.test.tsx
+++ b/src/components/JobStatsSummary.test.tsx
@@ -33,13 +33,20 @@ function makeScenarioItem(clusterJobPhases: ClusterJobPhase[]): UnifiedRunItem {
 }
 
 function makeGraphItem(nodeJobPhases: ClusterJobPhase[][]): UnifiedRunItem {
+  const allPhases = nodeJobPhases.flat();
   return {
     type: 'graph',
     graphRunName: 'graph-1',
     nodes: nodeJobPhases.map(phases => makeScenarioRun(phases)),
     phase: 'Succeeded',
     createdAt: '2026-01-01T00:00:00Z',
-    summary: { totalNodes: nodeJobPhases.length, completedNodes: 0, runningNodes: 0, failedNodes: 0, pendingNodes: 0 },
+    summary: {
+      totalNodes: allPhases.length,
+      completedNodes: allPhases.filter(p => p === 'Succeeded').length,
+      runningNodes: allPhases.filter(p => p === 'Running').length,
+      failedNodes: allPhases.filter(p => p === 'Failed').length,
+      pendingNodes: allPhases.filter(p => p === 'Pending').length,
+    },
   };
 }
 

--- a/src/components/JobStatsSummary.tsx
+++ b/src/components/JobStatsSummary.tsx
@@ -12,18 +12,36 @@ import {
   TachometerAltIcon,
 } from '@patternfly/react-icons';
 import type { UnifiedRunItem } from './JobsList';
-import type { ClusterJob } from '../types/api';
 
 interface JobStatsSummaryProps {
   unifiedRuns: UnifiedRunItem[];
 }
 
-function collectClusterJobs(items: UnifiedRunItem[]): ClusterJob[] {
-  return items.flatMap(item =>
-    item.type === 'scenario'
-      ? item.run.clusterJobs
-      : item.nodes.flatMap(node => node.clusterJobs)
-  );
+interface JobCounts {
+  total: number;
+  succeeded: number;
+  failed: number;
+}
+
+function collectJobCounts(items: UnifiedRunItem[]): JobCounts {
+  let total = 0;
+  let succeeded = 0;
+  let failed = 0;
+
+  for (const item of items) {
+    if (item.type === 'scenario') {
+      const jobs = item.run.clusterJobs;
+      total += jobs.length;
+      succeeded += jobs.filter(j => j.phase === 'Succeeded').length;
+      failed += jobs.filter(j => j.phase === 'Failed').length;
+    } else {
+      total += item.summary.totalNodes;
+      succeeded += item.summary.completedNodes;
+      failed += item.summary.failedNodes;
+    }
+  }
+
+  return { total, succeeded, failed };
 }
 
 const statCards = [
@@ -59,10 +77,7 @@ const statCards = [
 
 export function JobStatsSummary({ unifiedRuns }: JobStatsSummaryProps) {
   const stats = useMemo(() => {
-    const jobs = collectClusterJobs(unifiedRuns);
-    const total = jobs.length;
-    const succeeded = jobs.filter(j => j.phase === 'Succeeded').length;
-    const failed = jobs.filter(j => j.phase === 'Failed').length;
+    const { total, succeeded, failed } = collectJobCounts(unifiedRuns);
     const passRate = total > 0 ? ((succeeded / total) * 100).toFixed(1) + '%' : 'N/A';
     return { total, succeeded, failed, passRate };
   }, [unifiedRuns]);

--- a/src/components/JobStatsSummary.tsx
+++ b/src/components/JobStatsSummary.tsx
@@ -30,14 +30,15 @@ function collectJobCounts(items: UnifiedRunItem[]): JobCounts {
 
   for (const item of items) {
     if (item.type === 'scenario') {
-      const jobs = item.run.clusterJobs;
+      const jobs = item.run.clusterJobs ?? [];
       total += jobs.length;
       succeeded += jobs.filter(j => j.phase === 'Succeeded').length;
       failed += jobs.filter(j => j.phase === 'Failed').length;
     } else {
-      total += item.summary.totalNodes;
-      succeeded += item.summary.completedNodes;
-      failed += item.summary.failedNodes;
+      const summary = item.summary ?? { totalNodes: 0, completedNodes: 0, failedNodes: 0 };
+      total += summary.totalNodes;
+      succeeded += summary.completedNodes;
+      failed += summary.failedNodes;
     }
   }
 

--- a/src/components/JobsList.test.tsx
+++ b/src/components/JobsList.test.tsx
@@ -1,8 +1,25 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { JobsList } from './JobsList';
-import type { ScenarioRunState, ClusterJob, GraphRunState } from '../types/api';
+import type { ClusterJob, UnifiedJobItem, PaginationMeta, ScenarioRunStatusResponse, GraphRunListItem } from '../types/api';
+
+const mockSetPage = vi.fn();
+const mockSetLimit = vi.fn();
+let mockJobs: UnifiedJobItem[] = [];
+let mockPagination: PaginationMeta = { page: 1, limit: 20, total: 0, totalPages: 0 };
+let mockIsLoading = false;
+
+vi.mock('../hooks/useJobs', () => ({
+  useJobs: () => ({
+    jobs: mockJobs,
+    pagination: mockPagination,
+    page: mockPagination.page,
+    setPage: mockSetPage,
+    limit: mockPagination.limit,
+    setLimit: mockSetLimit,
+    isLoading: mockIsLoading,
+  }),
+}));
 
 vi.mock('../hooks/useRole', () => ({
   useRole: () => ({ isAdmin: false, role: 'user' }),
@@ -12,12 +29,35 @@ vi.mock('../hooks/useActiveRunsPoller', () => ({
   useActiveRunsPoller: () => ({ activeRuns: null, loading: false, error: null }),
 }));
 
+vi.mock('./GraphRunDetail', () => ({
+  GraphRunDetail: ({ graphRunName }: { graphRunName: string }) => (
+    <div data-testid={`graph-detail-${graphRunName}`}>Graph Detail Mock</div>
+  ),
+}));
+
+vi.mock('./LogViewer', () => ({
+  LogViewer: () => <div data-testid="log-viewer-mock" />,
+}));
+
+vi.mock('./ActiveRunsSummary', () => ({
+  ActiveRunsSummary: () => <div data-testid="active-runs-summary" />,
+}));
+
+vi.mock('./FileManagement', () => ({
+  FileManagementModal: () => null,
+}));
+
+vi.mock('react-icons/hi2', () => ({
+  HiOutlineRocketLaunch: () => <span data-testid="rocket-icon" />,
+}));
+
+const { JobsList } = await import('./JobsList');
+
 const noopSet = new Set<string>();
 const noop = () => {};
 const noopAsync = async () => {};
 
 const defaultProps = {
-  scenarioRuns: [] as ScenarioRunState[],
   expandedRunIds: noopSet,
   expandedJobIds: noopSet,
   onToggleRunAccordion: noop,
@@ -26,88 +66,114 @@ const defaultProps = {
   onDeleteJob: noopAsync,
   onCreateJob: noop,
   onNavigateToStudio: noop,
-  graphRuns: [] as GraphRunState[],
   expandedGraphRunIds: noopSet,
   onToggleGraphRunAccordion: noop,
   onDeleteGraphRun: noopAsync,
   onRerunScenario: noop,
 };
 
-function makeScenarioRun(
+function makeScenarioJobItem(
   name: string,
   phase: string,
-  jobs: { total: number; succeeded: number; failed: number } = { total: 1, succeeded: 0, failed: 0 },
-  overrides: Partial<ScenarioRunState> = {},
-): ScenarioRunState {
+  opts: {
+    clusterJobs?: ClusterJob[];
+    customRunName?: string;
+    createdAt?: string;
+    scenarioName?: string;
+  } = {},
+): UnifiedJobItem {
   return {
-    scenarioRunName: name,
-    phase,
-    totalTargets: jobs.total,
-    successfulJobs: jobs.succeeded,
-    failedJobs: jobs.failed,
-    runningJobs: 0,
-    clusterJobs: [],
-    scenarios: [],
-    createdAt: '2026-01-01T00:00:00Z',
-    ...overrides,
-  } as unknown as ScenarioRunState;
-}
-
-function makeGraphRun(
-  name: string,
-  phase: GraphRunState['phase'] = 'Running',
-  overrides: Partial<GraphRunState> = {},
-): GraphRunState {
-  return {
+    type: 'scenarioRun',
     name,
-    namespace: 'default',
-    creationTimestamp: '2026-01-01T00:00:00Z',
-    phase,
-    ownerUserId: 'user@example.com',
-    targetRequestId: 'req-123',
-    summary: { totalNodes: 1, completedNodes: 0, runningNodes: 1, failedNodes: 0, pendingNodes: 0 },
-    ...overrides,
+    createdAt: opts.createdAt || '2026-01-01T00:00:00Z',
+    scenarioRun: {
+      scenarioRunName: name,
+      scenarioName: opts.scenarioName,
+      phase: phase as ScenarioRunStatusResponse['phase'],
+      totalTargets: 1,
+      successfulJobs: (opts.clusterJobs || []).filter(j => j.phase === 'Succeeded').length,
+      failedJobs: (opts.clusterJobs || []).filter(j => j.phase === 'Failed').length,
+      runningJobs: (opts.clusterJobs || []).filter(j => j.phase === 'Running').length,
+      clusterJobs: opts.clusterJobs || [],
+      customRunName: opts.customRunName,
+    },
   };
 }
 
+function makeGraphJobItem(
+  name: string,
+  phase: GraphRunListItem['phase'] = 'Running',
+  overrides: Partial<GraphRunListItem> = {},
+): UnifiedJobItem {
+  return {
+    type: 'graphRun',
+    name,
+    createdAt: overrides.creationTimestamp || '2026-01-01T00:00:00Z',
+    graphRun: {
+      name,
+      namespace: 'default',
+      creationTimestamp: '2026-01-01T00:00:00Z',
+      phase,
+      ownerUserId: 'user@example.com',
+      targetRequestId: 'req-123',
+      summary: { totalNodes: 1, completedNodes: 0, runningNodes: 1, failedNodes: 0, pendingNodes: 0 },
+      ...overrides,
+    },
+  };
+}
+
+function setMockJobs(items: UnifiedJobItem[]) {
+  mockJobs = items;
+  mockPagination = { page: 1, limit: 20, total: items.length, totalPages: 1 };
+}
+
 describe('JobsList', () => {
-  it('does not render JobStatsSummary when there are no runs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockJobs = [];
+    mockPagination = { page: 1, limit: 20, total: 0, totalPages: 0 };
+    mockIsLoading = false;
+  });
+
+  it('shows empty state when no jobs', () => {
     render(<JobsList {...defaultProps} />);
     expect(screen.getByText('No Scenario Runs')).toBeInTheDocument();
     expect(screen.queryByText('Total Jobs')).not.toBeInTheDocument();
   });
 
-  it('renders JobStatsSummary when scenarioRuns are present', () => {
-    const makeJob = (phase: 'Succeeded' | 'Failed') => ({
+  it('shows loading state when loading with no jobs', () => {
+    mockIsLoading = true;
+    render(<JobsList {...defaultProps} />);
+    expect(screen.getByText('Loading Jobs')).toBeInTheDocument();
+  });
+
+  it('renders JobStatsSummary when jobs are present', () => {
+    const makeJob = (phase: 'Succeeded' | 'Failed'): ClusterJob => ({
       providerName: 'krkn-operator',
       clusterName: 'cluster-1',
-      jobId: `job-${Math.random()}`,
+      jobId: `job-${phase}`,
       podName: 'pod-1',
       phase,
     });
-    const runs = [
-      makeScenarioRun('run-1', 'Succeeded', { total: 3, succeeded: 3, failed: 0 }, {
+    setMockJobs([
+      makeScenarioJobItem('run-1', 'Succeeded', {
         clusterJobs: [makeJob('Succeeded'), makeJob('Succeeded'), makeJob('Succeeded')],
       }),
-      makeScenarioRun('run-2', 'Failed', { total: 2, succeeded: 0, failed: 2 }, {
+      makeScenarioJobItem('run-2', 'Failed', {
         clusterJobs: [makeJob('Failed'), makeJob('Failed')],
       }),
-    ];
-    render(<JobsList {...defaultProps} scenarioRuns={runs} />);
+    ]);
+    render(<JobsList {...defaultProps} />);
     expect(screen.getByText('Total Jobs')).toBeInTheDocument();
     expect(screen.getByText('Pass Rate')).toBeInTheDocument();
     expect(screen.getByText('60.0%')).toBeInTheDocument();
   });
 
   describe('Run Name Filter', () => {
-    it('matches a graph run by graphRunName and shows the row', async () => {
+    it('matches a graph run by name and shows the row', async () => {
       const user = userEvent.setup();
-      const graphRun = makeGraphRun('graphrun-abc123');
-      const node = makeScenarioRun('node-scenario-run-1', 'Running', { total: 1, succeeded: 0, failed: 0 }, {
-        graphRunName: 'graphrun-abc123',
-      });
-
-      render(<JobsList {...defaultProps} scenarioRuns={[node]} graphRuns={[graphRun]} />);
+      setMockJobs([makeGraphJobItem('graphrun-abc123')]);
+      render(<JobsList {...defaultProps} />);
 
       const filterInput = screen.getByRole('textbox', { name: /Filter by run name/i });
       await user.type(filterInput, 'graphrun-abc123');
@@ -117,14 +183,10 @@ describe('JobsList', () => {
       });
     });
 
-    it('hides a graph run when the filter does not match its graphRunName', async () => {
+    it('hides a graph run when the filter does not match', async () => {
       const user = userEvent.setup();
-      const graphRun = makeGraphRun('graphrun-abc123');
-      const node = makeScenarioRun('node-scenario-run-1', 'Running', { total: 1, succeeded: 0, failed: 0 }, {
-        graphRunName: 'graphrun-abc123',
-      });
-
-      render(<JobsList {...defaultProps} scenarioRuns={[node]} graphRuns={[graphRun]} />);
+      setMockJobs([makeGraphJobItem('graphrun-abc123')]);
+      render(<JobsList {...defaultProps} />);
 
       const filterInput = screen.getByRole('textbox', { name: /Filter by run name/i });
       await user.type(filterInput, 'unrelated-name');
@@ -135,29 +197,23 @@ describe('JobsList', () => {
       expect(screen.getByText('No Matching Runs')).toBeInTheDocument();
     });
 
-    it('matches a labeled standalone run by scenarioRunName even when customRunName is set', async () => {
+    it('matches a labeled standalone run by scenarioRunName', async () => {
       const user = userEvent.setup();
-      const run = makeScenarioRun('scenario-run-generated-id', 'Succeeded', undefined, {
-        customRunName: 'my-label',
-      });
-
-      render(<JobsList {...defaultProps} scenarioRuns={[run]} />);
+      setMockJobs([makeScenarioJobItem('scenario-run-id', 'Succeeded', { customRunName: 'my-label' })]);
+      render(<JobsList {...defaultProps} />);
 
       const filterInput = screen.getByRole('textbox', { name: /Filter by run name/i });
-      await user.type(filterInput, 'scenario-run-generated-id');
+      await user.type(filterInput, 'scenario-run-id');
 
       await waitFor(() => {
-        expect(screen.getByText('scenario-run-generated-id')).toBeInTheDocument();
+        expect(screen.getByText('scenario-run-id')).toBeInTheDocument();
       });
     });
 
     it('matches a labeled standalone run by customRunName', async () => {
       const user = userEvent.setup();
-      const run = makeScenarioRun('scenario-run-generated-id', 'Succeeded', undefined, {
-        customRunName: 'my-label',
-      });
-
-      render(<JobsList {...defaultProps} scenarioRuns={[run]} />);
+      setMockJobs([makeScenarioJobItem('scenario-run-id', 'Succeeded', { customRunName: 'my-label' })]);
+      render(<JobsList {...defaultProps} />);
 
       const filterInput = screen.getByRole('textbox', { name: /Filter by run name/i });
       await user.type(filterInput, 'my-label');
@@ -182,18 +238,6 @@ describe('JobsList - Re-run button', () => {
     ...overrides,
   });
 
-  const makeRerunRun = (jobs: ClusterJob[]): ScenarioRunState => ({
-    scenarioRunName: 'run-001',
-    scenarioName: 'node-cpu-hog',
-    phase: jobs.some(j => j.phase === 'Running') ? 'Running' : 'Succeeded',
-    totalTargets: jobs.length,
-    successfulJobs: jobs.filter(j => j.phase === 'Succeeded').length,
-    failedJobs: jobs.filter(j => j.phase === 'Failed').length,
-    runningJobs: jobs.filter(j => j.phase === 'Running').length,
-    clusterJobs: jobs,
-    createdAt: '2026-07-29T10:00:00Z',
-  });
-
   const rerunDefaultProps = {
     expandedRunIds: new Set<string>(['run-001']),
     expandedJobIds: new Set<string>(),
@@ -204,7 +248,6 @@ describe('JobsList - Re-run button', () => {
     onCreateJob: vi.fn(),
     onNavigateToStudio: vi.fn(),
     onRerunScenario: mockOnRerunScenario,
-    graphRuns: [] as GraphRunState[],
     expandedGraphRunIds: new Set<string>(),
     onToggleGraphRunAccordion: vi.fn(),
     onDeleteGraphRun: vi.fn(),
@@ -212,107 +255,84 @@ describe('JobsList - Re-run button', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsLoading = false;
   });
 
-  it('should not show Re-run button for a running job (no completionTime)', () => {
-    const jobs = [makeJob({ phase: 'Running' })];
-    render(<JobsList {...rerunDefaultProps} scenarioRuns={[makeRerunRun(jobs)]} />);
-
+  it('should not show Re-run button for a running job', () => {
+    setMockJobs([makeScenarioJobItem('run-001', 'Running', { clusterJobs: [makeJob({ phase: 'Running' })] })]);
+    render(<JobsList {...rerunDefaultProps} />);
     expect(screen.queryByLabelText('Re-run scenario')).not.toBeInTheDocument();
   });
 
   it('should not show Re-run button for a pending job', () => {
-    const jobs = [makeJob({ phase: 'Pending' })];
-    render(<JobsList {...rerunDefaultProps} scenarioRuns={[makeRerunRun(jobs)]} />);
-
+    setMockJobs([makeScenarioJobItem('run-001', 'Pending', { clusterJobs: [makeJob({ phase: 'Pending' })] })]);
+    render(<JobsList {...rerunDefaultProps} />);
     expect(screen.queryByLabelText('Re-run scenario')).not.toBeInTheDocument();
   });
 
-  it('should show Re-run button for a completed job (has completionTime)', () => {
-    const jobs = [makeJob({ phase: 'Succeeded', completionTime: '2026-07-29T11:00:00Z' })];
-    render(<JobsList {...rerunDefaultProps} scenarioRuns={[makeRerunRun(jobs)]} />);
-
+  it('should show Re-run button for a completed job', () => {
+    setMockJobs([makeScenarioJobItem('run-001', 'Succeeded', {
+      clusterJobs: [makeJob({ phase: 'Succeeded', completionTime: '2026-07-29T11:00:00Z' })],
+    })]);
+    render(<JobsList {...rerunDefaultProps} />);
     expect(screen.getByLabelText('Re-run scenario')).toBeInTheDocument();
   });
 
   it('should show Re-run button for a failed job with completionTime', () => {
-    const jobs = [makeJob({ phase: 'Failed', completionTime: '2026-07-29T11:00:00Z', message: 'OOM killed' })];
-    render(<JobsList {...rerunDefaultProps} scenarioRuns={[makeRerunRun(jobs)]} />);
-
+    setMockJobs([makeScenarioJobItem('run-001', 'Failed', {
+      clusterJobs: [makeJob({ phase: 'Failed', completionTime: '2026-07-29T11:00:00Z', message: 'OOM' })],
+    })]);
+    render(<JobsList {...rerunDefaultProps} />);
     expect(screen.getByLabelText('Re-run scenario')).toBeInTheDocument();
   });
 
-  it('should call onRerunScenario with correct args when Re-run clicked', async () => {
+  it('should call onRerunScenario with correct args', async () => {
     const user = userEvent.setup();
     const jobs = [makeJob({ phase: 'Succeeded', completionTime: '2026-07-29T11:00:00Z' })];
-    const run = makeRerunRun(jobs);
-    render(<JobsList {...rerunDefaultProps} scenarioRuns={[run]} />);
+    setMockJobs([makeScenarioJobItem('run-001', 'Succeeded', { clusterJobs: jobs, createdAt: '2026-07-29T10:00:00Z' })]);
+    render(<JobsList {...rerunDefaultProps} />);
 
     await user.click(screen.getByLabelText('Re-run scenario'));
-
     expect(mockOnRerunScenario).toHaveBeenCalledTimes(1);
-    expect(mockOnRerunScenario).toHaveBeenCalledWith(run, 'job-001');
+    const [calledRun, calledJobId] = mockOnRerunScenario.mock.calls[0];
+    expect(calledRun.scenarioRunName).toBe('run-001');
+    expect(calledJobId).toBe('job-001');
   });
 
   it('should show Re-run only for completed jobs in a mixed-status run', () => {
-    const jobs = [
-      makeJob({ jobId: 'job-running', phase: 'Running' }),
-      makeJob({ jobId: 'job-done', phase: 'Succeeded', completionTime: '2026-07-29T11:00:00Z', clusterName: 'cluster-2' }),
-    ];
-    render(<JobsList {...rerunDefaultProps} scenarioRuns={[makeRerunRun(jobs)]} />);
-
+    setMockJobs([makeScenarioJobItem('run-001', 'Running', {
+      clusterJobs: [
+        makeJob({ jobId: 'job-running', phase: 'Running' }),
+        makeJob({ jobId: 'job-done', phase: 'Succeeded', completionTime: '2026-07-29T11:00:00Z', clusterName: 'cluster-2' }),
+      ],
+    })]);
+    render(<JobsList {...rerunDefaultProps} />);
     const rerunButtons = screen.getAllByLabelText('Re-run scenario');
     expect(rerunButtons).toHaveLength(1);
   });
 
   it('should not show Re-run button for graph runs', () => {
-
-    const graphRun: GraphRunState = {
-      name: 'graphrun-001',
-      namespace: 'default',
-      creationTimestamp: '2026-07-29T10:00:00Z',
-      phase: 'Completed',
-      ownerUserId: 'user@example.com',
-      targetRequestId: 'uuid-001',
-      summary: { totalNodes: 1, completedNodes: 1, runningNodes: 0, failedNodes: 0, pendingNodes: 0 },
+    setMockJobs([makeGraphJobItem('graphrun-001', 'Completed', {
       completionTime: '2026-07-29T11:00:00Z',
-    };
-
-    const graphNodeRun: ScenarioRunState = {
-      scenarioRunName: 'run-graph-001',
-      scenarioName: 'node-cpu-hog',
-      phase: 'Succeeded',
-      totalTargets: 1,
-      successfulJobs: 1,
-      failedJobs: 0,
-      runningJobs: 0,
-      clusterJobs: [makeJob({ phase: 'Succeeded', completionTime: '2026-07-29T11:00:00Z' })],
-      createdAt: '2026-07-29T10:00:00Z',
-      graphRunName: 'graphrun-001',
-      graphNodeId: 'node-1',
-    };
-
-    render(
-      <JobsList
-        {...rerunDefaultProps}
-        scenarioRuns={[graphNodeRun]}
-        graphRuns={[graphRun]}
-        expandedRunIds={new Set<string>()}
-        expandedGraphRunIds={new Set<string>(['graphrun-001'])}
-      />
-    );
-
+    })]);
+    render(<JobsList {...rerunDefaultProps} expandedGraphRunIds={new Set(['graphrun-001'])} />);
     expect(screen.queryByLabelText('Re-run scenario')).not.toBeInTheDocument();
   });
 });
 
 describe('JobsList - Date/Time Filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+  });
+
   it('hides a scenario run whose createdAt is before the "from" date', async () => {
     const user = userEvent.setup();
-    const oldRun = makeScenarioRun('run-old', 'Succeeded', undefined, { createdAt: '2026-01-14T12:00:00.000Z' });
-    const newRun = makeScenarioRun('run-new', 'Succeeded', undefined, { createdAt: '2026-01-15T12:00:00.000Z' });
-
-    render(<JobsList {...defaultProps} scenarioRuns={[oldRun, newRun]} />);
+    setMockJobs([
+      makeScenarioJobItem('run-old', 'Succeeded', { createdAt: '2026-01-14T12:00:00.000Z' }),
+      makeScenarioJobItem('run-new', 'Succeeded', { createdAt: '2026-01-15T12:00:00.000Z' }),
+    ]);
+    render(<JobsList {...defaultProps} />);
 
     await user.type(screen.getByRole('textbox', { name: 'Start date' }), '2026-01-15');
 
@@ -324,10 +344,11 @@ describe('JobsList - Date/Time Filter', () => {
 
   it('hides a scenario run whose createdAt is after the "to" datetime', async () => {
     const user = userEvent.setup();
-    const insideRun = makeScenarioRun('run-inside', 'Succeeded', undefined, { createdAt: '2026-01-15T12:00:00.000Z' });
-    const outsideRun = makeScenarioRun('run-outside', 'Succeeded', undefined, { createdAt: '2026-01-16T12:00:00.000Z' });
-
-    render(<JobsList {...defaultProps} scenarioRuns={[insideRun, outsideRun]} />);
+    setMockJobs([
+      makeScenarioJobItem('run-inside', 'Succeeded', { createdAt: '2026-01-15T12:00:00.000Z' }),
+      makeScenarioJobItem('run-outside', 'Succeeded', { createdAt: '2026-01-16T12:00:00.000Z' }),
+    ]);
+    render(<JobsList {...defaultProps} />);
 
     await user.type(screen.getByRole('textbox', { name: 'Start date' }), '2026-01-15');
     await user.type(screen.getByRole('textbox', { name: 'End date' }), '2026-01-15');
@@ -339,13 +360,13 @@ describe('JobsList - Date/Time Filter', () => {
     });
   });
 
-  it('hides a graph run whose creationTimestamp is before the "from" date', async () => {
+  it('hides a graph run whose createdAt is before the "from" date', async () => {
     const user = userEvent.setup();
-    // Scenario run is needed both for the filter UI to appear and to pass the filter
-    const controlRun = makeScenarioRun('run-control', 'Succeeded', undefined, { createdAt: '2026-01-16T12:00:00.000Z' });
-    const graphRun = makeGraphRun('graphrun-old', 'Completed', { creationTimestamp: '2026-01-14T12:00:00.000Z' });
-
-    render(<JobsList {...defaultProps} scenarioRuns={[controlRun]} graphRuns={[graphRun]} />);
+    setMockJobs([
+      makeScenarioJobItem('run-control', 'Succeeded', { createdAt: '2026-01-16T12:00:00.000Z' }),
+      makeGraphJobItem('graphrun-old', 'Completed', { creationTimestamp: '2026-01-14T12:00:00.000Z' }),
+    ]);
+    render(<JobsList {...defaultProps} />);
 
     await user.type(screen.getByRole('textbox', { name: 'Start date' }), '2026-01-16');
 
@@ -355,12 +376,13 @@ describe('JobsList - Date/Time Filter', () => {
     });
   });
 
-  it('shows a graph run whose creationTimestamp is within the date range', async () => {
+  it('shows a graph run whose createdAt is within the date range', async () => {
     const user = userEvent.setup();
-    const controlRun = makeScenarioRun('run-control', 'Succeeded', undefined, { createdAt: '2026-01-15T12:00:00.000Z' });
-    const graphRun = makeGraphRun('graphrun-inside', 'Running', { creationTimestamp: '2026-01-15T12:00:00.000Z' });
-
-    render(<JobsList {...defaultProps} scenarioRuns={[controlRun]} graphRuns={[graphRun]} />);
+    setMockJobs([
+      makeScenarioJobItem('run-control', 'Succeeded', { createdAt: '2026-01-15T12:00:00.000Z' }),
+      makeGraphJobItem('graphrun-inside', 'Running', { creationTimestamp: '2026-01-15T12:00:00.000Z' }),
+    ]);
+    render(<JobsList {...defaultProps} />);
 
     await user.type(screen.getByRole('textbox', { name: 'Start date' }), '2026-01-15');
 
@@ -371,9 +393,8 @@ describe('JobsList - Date/Time Filter', () => {
 
   it('shows a time range error when same-day start time is after end time', async () => {
     const user = userEvent.setup();
-    const run = makeScenarioRun('run-1', 'Succeeded', undefined, { createdAt: '2026-01-15T12:00:00.000Z' });
-
-    render(<JobsList {...defaultProps} scenarioRuns={[run]} />);
+    setMockJobs([makeScenarioJobItem('run-1', 'Succeeded', { createdAt: '2026-01-15T12:00:00.000Z' })]);
+    render(<JobsList {...defaultProps} />);
 
     await user.type(screen.getByRole('textbox', { name: 'Start date' }), '2026-01-15');
     await user.type(screen.getByRole('textbox', { name: 'End date' }), '2026-01-15');
@@ -387,10 +408,11 @@ describe('JobsList - Date/Time Filter', () => {
 
   it('clears date filter and restores hidden runs when "Clear all filters" is clicked', async () => {
     const user = userEvent.setup();
-    const oldRun = makeScenarioRun('run-old', 'Succeeded', undefined, { createdAt: '2026-01-14T12:00:00.000Z' });
-    const newRun = makeScenarioRun('run-new', 'Succeeded', undefined, { createdAt: '2026-01-15T12:00:00.000Z' });
-
-    render(<JobsList {...defaultProps} scenarioRuns={[oldRun, newRun]} />);
+    setMockJobs([
+      makeScenarioJobItem('run-old', 'Succeeded', { createdAt: '2026-01-14T12:00:00.000Z' }),
+      makeScenarioJobItem('run-new', 'Succeeded', { createdAt: '2026-01-15T12:00:00.000Z' }),
+    ]);
+    render(<JobsList {...defaultProps} />);
 
     await user.type(screen.getByRole('textbox', { name: 'Start date' }), '2026-01-15');
 
@@ -404,5 +426,25 @@ describe('JobsList - Date/Time Filter', () => {
       expect(screen.getByText('run-old')).toBeInTheDocument();
       expect(screen.getByText('run-new')).toBeInTheDocument();
     });
+  });
+});
+
+describe('JobsList - Pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+  });
+
+  it('does not show pagination when totalPages <= 1', () => {
+    setMockJobs([makeScenarioJobItem('run-1', 'Succeeded')]);
+    render(<JobsList {...defaultProps} />);
+    expect(screen.queryByLabelText(/Go to next page/i)).not.toBeInTheDocument();
+  });
+
+  it('shows pagination when totalPages > 1', () => {
+    mockJobs = [makeScenarioJobItem('run-1', 'Succeeded')];
+    mockPagination = { page: 1, limit: 10, total: 25, totalPages: 3 };
+    render(<JobsList {...defaultProps} />);
+    expect(screen.getByLabelText('Go to next page')).toBeInTheDocument();
   });
 });

--- a/src/components/JobsList.test.tsx
+++ b/src/components/JobsList.test.tsx
@@ -1,25 +1,10 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import type { ClusterJob, UnifiedJobItem, PaginationMeta, ScenarioRunStatusResponse, GraphRunListItem } from '../types/api';
+import type { ClusterJob, UnifiedJobItem, ScenarioRunStatusResponse, GraphRunListItem } from '../types/api';
+import { setMockJobs, setMockIsLoading, setMockPagination, resetJobsMock } from '../hooks/__mocks__/useJobs';
 
-const mockSetPage = vi.fn();
-const mockSetLimit = vi.fn();
-let mockJobs: UnifiedJobItem[] = [];
-let mockPagination: PaginationMeta = { page: 1, limit: 20, total: 0, totalPages: 0 };
-let mockIsLoading = false;
-
-vi.mock('../hooks/useJobs', () => ({
-  useJobs: () => ({
-    jobs: mockJobs,
-    pagination: mockPagination,
-    page: mockPagination.page,
-    setPage: mockSetPage,
-    limit: mockPagination.limit,
-    setLimit: mockSetLimit,
-    isLoading: mockIsLoading,
-  }),
-}));
+vi.mock('../hooks/useJobs');
 
 vi.mock('../hooks/useRole', () => ({
   useRole: () => ({ isAdmin: false, role: 'user' }),
@@ -122,17 +107,10 @@ function makeGraphJobItem(
   };
 }
 
-function setMockJobs(items: UnifiedJobItem[]) {
-  mockJobs = items;
-  mockPagination = { page: 1, limit: 20, total: items.length, totalPages: 1 };
-}
-
 describe('JobsList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockJobs = [];
-    mockPagination = { page: 1, limit: 20, total: 0, totalPages: 0 };
-    mockIsLoading = false;
+    resetJobsMock();
   });
 
   it('shows empty state when no jobs', () => {
@@ -142,7 +120,7 @@ describe('JobsList', () => {
   });
 
   it('shows loading state when loading with no jobs', () => {
-    mockIsLoading = true;
+    setMockIsLoading(true);
     render(<JobsList {...defaultProps} />);
     expect(screen.getByText('Loading Jobs')).toBeInTheDocument();
   });
@@ -255,7 +233,7 @@ describe('JobsList - Re-run button', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockIsLoading = false;
+    setMockIsLoading(false);
   });
 
   it('should not show Re-run button for a running job', () => {
@@ -323,7 +301,7 @@ describe('JobsList - Re-run button', () => {
 describe('JobsList - Date/Time Filter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockIsLoading = false;
+    setMockIsLoading(false);
   });
 
   it('hides a scenario run whose createdAt is before the "from" date', async () => {
@@ -432,7 +410,7 @@ describe('JobsList - Date/Time Filter', () => {
 describe('JobsList - Pagination', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockIsLoading = false;
+    setMockIsLoading(false);
   });
 
   it('does not show pagination when totalPages <= 1', () => {
@@ -442,8 +420,8 @@ describe('JobsList - Pagination', () => {
   });
 
   it('shows pagination when totalPages > 1', () => {
-    mockJobs = [makeScenarioJobItem('run-1', 'Succeeded')];
-    mockPagination = { page: 1, limit: 10, total: 25, totalPages: 3 };
+    setMockJobs([makeScenarioJobItem('run-1', 'Succeeded')]);
+    setMockPagination({ page: 1, limit: 10, total: 25, totalPages: 3 });
     render(<JobsList {...defaultProps} />);
     expect(screen.getByLabelText('Go to next page')).toBeInTheDocument();
   });

--- a/src/components/JobsList.tsx
+++ b/src/components/JobsList.tsx
@@ -35,6 +35,9 @@ import {
   DropdownList,
   DropdownItem,
   TextInput,
+  Pagination,
+  PaginationVariant,
+  Spinner,
 } from '@patternfly/react-core';
 import {
   HourglassHalfIcon,
@@ -56,11 +59,11 @@ import { JobStatsSummary } from './JobStatsSummary';
 import { FileManagementModal } from './FileManagement';
 import { useRole } from '../hooks/useRole';
 import { useActiveRunsPoller } from '../hooks/useActiveRunsPoller';
+import { useJobs } from '../hooks/useJobs';
 import { ResiliencyScoreTooltip } from './ResiliencyScoreTooltip';
 
-import type { ScenarioRunState, ScenarioRunPhase, ClusterJobPhase, GraphRunState, GraphRunSummary, GraphClusterScore } from '../types/api';
+import type { ScenarioRunState, ScenarioRunPhase, ClusterJobPhase, GraphRunSummary, GraphClusterScore, UnifiedJobItem } from '../types/api';
 
-// Unified run item type - can be either a GraphRun or a standalone ScenarioRun
 export type UnifiedRunItem =
   | {
       type: 'graph';
@@ -76,8 +79,52 @@ export type UnifiedRunItem =
     }
   | { type: 'scenario'; run: ScenarioRunState };
 
+function toUnifiedRunItem(item: UnifiedJobItem): UnifiedRunItem | null {
+  if (item.type === 'graphRun' && item.graphRun) {
+    const gr = item.graphRun;
+    let phase: ScenarioRunPhase = 'Pending';
+    if (gr.phase === 'Completed') phase = 'Succeeded';
+    else if (gr.phase === 'Running' || gr.phase === 'Failed' || gr.phase === 'PartiallyFailed' || gr.phase === 'Pending') {
+      phase = gr.phase;
+    }
+    return {
+      type: 'graph',
+      graphRunName: gr.name,
+      nodes: [],
+      phase,
+      createdAt: gr.creationTimestamp,
+      ownerUserId: gr.ownerUserId,
+      summary: gr.summary,
+      resiliencyScoreEnabled: gr.resiliencyScoreEnabled,
+      resiliencyScoreBaseline: gr.resiliencyScoreBaseline,
+      resiliencyScores: gr.resiliencyScores,
+    };
+  }
+  if (item.type === 'scenarioRun' && item.scenarioRun) {
+    const sr = item.scenarioRun;
+    return {
+      type: 'scenario',
+      run: {
+        scenarioRunName: sr.scenarioRunName,
+        scenarioName: sr.scenarioName || '',
+        phase: sr.phase,
+        totalTargets: sr.totalTargets,
+        successfulJobs: sr.successfulJobs,
+        failedJobs: sr.failedJobs,
+        runningJobs: sr.runningJobs,
+        clusterJobs: sr.clusterJobs,
+        createdAt: item.createdAt,
+        ownerUserId: sr.ownerUserId,
+        registryName: sr.registryName,
+        graphRunName: sr.graphRunName,
+        customRunName: sr.customRunName,
+      },
+    };
+  }
+  return null;
+}
+
 interface JobsListProps {
-  scenarioRuns: ScenarioRunState[];
   expandedRunIds: Set<string>;
   expandedJobIds: Set<string>;
   onToggleRunAccordion: (scenarioRunName: string) => void;
@@ -87,15 +134,12 @@ interface JobsListProps {
   onCreateJob: () => void;
   onNavigateToStudio: () => void;
   onRerunScenario: (run: ScenarioRunState, jobId: string) => void;
-  // GraphRuns props
-  graphRuns: GraphRunState[];
   expandedGraphRunIds: Set<string>;
   onToggleGraphRunAccordion: (graphRunName: string) => void;
   onDeleteGraphRun: (graphRunName: string) => Promise<void>;
 }
 
 export function JobsList({
-  scenarioRuns,
   expandedRunIds,
   expandedJobIds,
   onToggleRunAccordion,
@@ -105,13 +149,13 @@ export function JobsList({
   onCreateJob,
   onNavigateToStudio,
   onRerunScenario,
-  graphRuns: _graphRuns, // Not used - GraphRuns are derived from scenarioRuns
   expandedGraphRunIds,
   onToggleGraphRunAccordion,
   onDeleteGraphRun,
 }: JobsListProps) {
   const { isAdmin } = useRole();
   const { activeRuns, loading: activeRunsLoading, error: activeRunsError } = useActiveRunsPoller();
+  const { jobs, pagination, page, setPage, limit, setLimit, isLoading } = useJobs();
   const [deletingRun, setDeletingRun] = useState<string | null>(null);
   const [deletingJob, setDeletingJob] = useState<string | null>(null);
   const [confirmDeleteRun, setConfirmDeleteRun] = useState<string | null>(null);
@@ -121,9 +165,6 @@ export function JobsList({
   const [dateTimeTo, setDateTimeTo] = useState<Date | undefined>();
   const [timeRangeError, setTimeRangeError] = useState('');
   const [customRunNameFilter, setCustomRunNameFilter] = useState<string>('');
-  const [sortField, setSortField] = useState<'date' | 'runName'>('date');
-  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
-  const [isSortSelectOpen, setIsSortSelectOpen] = useState(false);
   const [isOwnerSelectOpen, setIsOwnerSelectOpen] = useState(false);
   const [isRunDropdownOpen, setIsRunDropdownOpen] = useState(false);
   const [isFileManagementOpen, setIsFileManagementOpen] = useState(false);
@@ -300,165 +341,47 @@ export function JobsList({
     }
   };
 
-  // Get unique owner user IDs for autocomplete
-  const uniqueOwners = Array.from(
-    new Set(scenarioRuns.map((run) => run.ownerUserId).filter((id): id is string => !!id))
-  ).sort();
-
-  // Filter scenario runs by owner and date range only (run-name filter is applied after graph aggregation)
-  const filteredScenarioRuns = scenarioRuns.filter((run) => {
-    // Owner filter (exact match)
-    if (ownerFilter && run.ownerUserId !== ownerFilter) {
-      return false;
-    }
-
-    // Date range filter
-    if (isValidDate(dateTimeFrom) || isValidDate(dateTimeTo)) {
-      const runDate = new Date(run.createdAt);
-
-      // Guard: exclude runs with invalid/empty createdAt when a date filter is active
-      if (isNaN(runDate.getTime())) return false;
-
-      if (isValidDate(dateTimeFrom) && runDate < dateTimeFrom!) return false;
-      if (isValidDate(dateTimeTo) && runDate > dateTimeTo!) return false;
-    }
-
-    return true;
-  });
-
-  // Group scenario runs into unified items (GraphRuns + standalone ScenarioRuns)
+  // Map API items → internal rendering items (server handles merging/sorting/pagination)
   const unifiedRuns = useMemo((): UnifiedRunItem[] => {
-    const graphRunsMap = new Map<string, ScenarioRunState[]>();
-    const standaloneRuns: ScenarioRunState[] = [];
+    return jobs.map(toUnifiedRunItem).filter((item): item is UnifiedRunItem => item !== null);
+  }, [jobs]);
 
-    // Group by graphRunName
-    filteredScenarioRuns.forEach((run) => {
-      if (run.graphRunName) {
-        const nodes = graphRunsMap.get(run.graphRunName) || [];
-        nodes.push(run);
-        graphRunsMap.set(run.graphRunName, nodes);
-      } else {
-        standaloneRuns.push(run);
-      }
-    });
+  // Get unique owner user IDs from current page for autocomplete
+  const uniqueOwners = useMemo(() => {
+    return Array.from(
+      new Set(
+        unifiedRuns.map((item) =>
+          item.type === 'graph' ? item.ownerUserId : item.run.ownerUserId
+        ).filter((id): id is string => !!id)
+      )
+    ).sort();
+  }, [unifiedRuns]);
 
-    // Build unified items
-    const items: UnifiedRunItem[] = [];
-
-    // Add GraphRuns from state (even if no nodes yet - WebSocket sends GraphRun before nodes)
-    _graphRuns.forEach((graphRunState) => {
-      const nodes = graphRunsMap.get(graphRunState.name) || [];
-
-      // Remove from map so we don't add it twice
-      graphRunsMap.delete(graphRunState.name);
-
-      // Apply the same date filter to graph runs
-      if (isValidDate(dateTimeFrom) || isValidDate(dateTimeTo)) {
-        const runDate = new Date(graphRunState.creationTimestamp);
-        if (isNaN(runDate.getTime())) return;
-        if (isValidDate(dateTimeFrom) && runDate < dateTimeFrom!) return;
-        if (isValidDate(dateTimeTo) && runDate > dateTimeTo!) return;
-      }
-
-      // Map GraphRun phase ('Completed') to ScenarioRun phase ('Succeeded')
-      let phase: ScenarioRunPhase = 'Pending';
-      if (graphRunState.phase === 'Completed') {
-        phase = 'Succeeded';
-      } else if (graphRunState.phase === 'Pending' || graphRunState.phase === 'Running' ||
-        graphRunState.phase === 'Failed' || graphRunState.phase === 'PartiallyFailed') {
-        phase = graphRunState.phase;
-      }
-
-      items.push({
-        type: 'graph',
-        graphRunName: graphRunState.name,
-        nodes,
-        phase,
-        createdAt: graphRunState.creationTimestamp,
-        ownerUserId: graphRunState.ownerUserId,
-        summary: graphRunState.summary,
-        resiliencyScoreEnabled: graphRunState.resiliencyScoreEnabled,
-        resiliencyScoreBaseline: graphRunState.resiliencyScoreBaseline,
-        resiliencyScores: graphRunState.resiliencyScores,
-      });
-    });
-
-    // Add orphaned GraphRuns (nodes without GraphRunState - shouldn't happen with WebSocket)
-    graphRunsMap.forEach((nodes, graphRunName) => {
-      const hasFailed = nodes.some((n) => n.phase === 'Failed');
-      const hasPartiallyFailed = nodes.some((n) => n.phase === 'PartiallyFailed');
-      const hasRunning = nodes.some((n) => n.phase === 'Running');
-      const allSucceeded = nodes.every((n) => n.phase === 'Succeeded');
-
-      let phase: ScenarioRunPhase = 'Pending';
-      if (hasFailed || hasPartiallyFailed) {
-        phase = 'Failed';
-      } else if (allSucceeded) {
-        phase = 'Succeeded';
-      } else if (hasRunning) {
-        phase = 'Running';
-      }
-
-      const createdAt = nodes.reduce((earliest, node) =>
-        node.createdAt < earliest ? node.createdAt : earliest
-        , nodes[0].createdAt);
-
-      const summary = {
-        totalNodes: nodes.length,
-        completedNodes: nodes.filter(n => n.phase === 'Succeeded').length,
-        runningNodes: nodes.filter(n => n.phase === 'Running').length,
-        failedNodes: nodes.filter(n => n.phase === 'Failed').length,
-        pendingNodes: nodes.filter(n => n.phase === 'Pending').length,
-      };
-
-      items.push({
-        type: 'graph',
-        graphRunName,
-        nodes,
-        phase,
-        createdAt,
-        ownerUserId: nodes[0].ownerUserId,
-        summary,
-      });
-    });
-
-    // Add standalone ScenarioRuns
-    standaloneRuns.forEach((run) => {
-      items.push({ type: 'scenario', run });
-    });
-
-    // Sort by selected field
-    return items.sort((a, b) => {
-      let cmp = 0;
-      if (sortField === 'runName') {
-        const aName = a.type === 'graph'
-          ? a.graphRunName
-          : (a.run.customRunName || a.run.scenarioRunName);
-        const bName = b.type === 'graph'
-          ? b.graphRunName
-          : (b.run.customRunName || b.run.scenarioRunName);
-        cmp = aName.localeCompare(bName);
-      } else {
-        const aDate = a.type === 'graph' ? a.createdAt : a.run.createdAt;
-        const bDate = b.type === 'graph' ? b.createdAt : b.run.createdAt;
-        cmp = (Date.parse(aDate) || 0) - (Date.parse(bDate) || 0);
-      }
-      return sortDir === 'asc' ? cmp : -cmp;
-    });
-  }, [filteredScenarioRuns, _graphRuns, sortField, sortDir, dateTimeFrom, dateTimeTo]);
-
-  // Apply run-name filter to the aggregated list so graph items are matched by graphRunName
-  // and filtering never strips individual nodes from an otherwise-matching graph.
+  // Client-side filtering on current page
   const filteredUnifiedRuns = useMemo((): UnifiedRunItem[] => {
-    if (!customRunNameFilter) return unifiedRuns;
-    const needle = customRunNameFilter.toLowerCase();
     return unifiedRuns.filter((item) => {
-      const haystacks = item.type === 'graph'
-        ? [item.graphRunName.toLowerCase()]
-        : [item.run.scenarioRunName.toLowerCase(), ...(item.run.customRunName ? [item.run.customRunName.toLowerCase()] : [])];
-      return haystacks.some((h) => h.includes(needle));
+      const owner = item.type === 'graph' ? item.ownerUserId : item.run.ownerUserId;
+      if (ownerFilter && owner !== ownerFilter) return false;
+
+      if (isValidDate(dateTimeFrom) || isValidDate(dateTimeTo)) {
+        const dateStr = item.type === 'graph' ? item.createdAt : item.run.createdAt;
+        const runDate = new Date(dateStr);
+        if (isNaN(runDate.getTime())) return false;
+        if (isValidDate(dateTimeFrom) && runDate < dateTimeFrom!) return false;
+        if (isValidDate(dateTimeTo) && runDate > dateTimeTo!) return false;
+      }
+
+      if (customRunNameFilter) {
+        const needle = customRunNameFilter.toLowerCase();
+        const haystacks = item.type === 'graph'
+          ? [item.graphRunName.toLowerCase()]
+          : [item.run.scenarioRunName.toLowerCase(), ...(item.run.customRunName ? [item.run.customRunName.toLowerCase()] : [])];
+        if (!haystacks.some((h) => h.includes(needle))) return false;
+      }
+
+      return true;
     });
-  }, [unifiedRuns, customRunNameFilter]);
+  }, [unifiedRuns, ownerFilter, dateTimeFrom, dateTimeTo, customRunNameFilter]);
 
   return (
     <Card>
@@ -542,7 +465,7 @@ export function JobsList({
         />
 
         {/* Filters Box */}
-        {scenarioRuns.length > 0 && (
+        {jobs.length > 0 && (
           <Card
             isCompact
             style={{
@@ -576,47 +499,6 @@ export function JobsList({
                     aria-label="Filter by run name"
                     style={{ width: '222px' }}
                   />
-                </div>
-
-                {/* Sort Controls */}
-                <div>
-                  <div style={{ marginBottom: '0.5rem', fontSize: 'var(--pf-v5-global--FontSize--sm)', fontWeight: 'bold' }}>
-                    Sort by:
-                  </div>
-                  <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
-                    <Select
-                      isOpen={isSortSelectOpen}
-                      onOpenChange={(isOpen) => setIsSortSelectOpen(isOpen)}
-                      onSelect={(_event, value) => {
-                        setSortField(value as 'date' | 'runName');
-                        setIsSortSelectOpen(false);
-                      }}
-                      toggle={(toggleRef) => (
-                        <MenuToggle
-                          ref={toggleRef}
-                          onClick={() => setIsSortSelectOpen(!isSortSelectOpen)}
-                          isExpanded={isSortSelectOpen}
-                          style={{ width: '130px' }}
-                          className="custom-select-toggle"
-                        >
-                          {sortField === 'date' ? 'Date' : 'Run Name'}
-                        </MenuToggle>
-                      )}
-                    >
-                      <SelectList>
-                        <SelectOption value="date">Date</SelectOption>
-                        <SelectOption value="runName">Run Name</SelectOption>
-                      </SelectList>
-                    </Select>
-                    <Button
-                      variant="plain"
-                      aria-label={sortDir === 'asc' ? 'Sort ascending' : 'Sort descending'}
-                      onClick={() => setSortDir(d => d === 'asc' ? 'desc' : 'asc')}
-                      style={{ padding: '0.375rem 0.5rem' }}
-                    >
-                      {sortDir === 'asc' ? '↑ Asc' : '↓ Desc'}
-                    </Button>
-                  </div>
                 </div>
 
                 {/* Owner Filter - Search with Autocomplete (Admin Only) */}
@@ -668,7 +550,7 @@ export function JobsList({
                 )}
 
                 {/* Date From Filter */}
-                {scenarioRuns.length > 0 && (
+                {jobs.length > 0 && (
                   <div>
                     <div style={{ marginBottom: '0.5rem', fontSize: 'var(--pf-v5-global--FontSize--sm)', fontWeight: 'bold' }}>
                       From:
@@ -700,7 +582,7 @@ export function JobsList({
                 )}
 
                 {/* Date To Filter */}
-                {scenarioRuns.length > 0 && (
+                {jobs.length > 0 && (
                   <div>
                     <div style={{ marginBottom: '0.5rem', fontSize: 'var(--pf-v5-global--FontSize--sm)', fontWeight: 'bold' }}>
                       To:
@@ -763,7 +645,15 @@ export function JobsList({
           </Card>
         )}
 
-        {filteredUnifiedRuns.length === 0 && scenarioRuns.length > 0 ? (
+        {isLoading && jobs.length === 0 ? (
+          <EmptyState>
+            <EmptyStateIcon icon={Spinner} />
+            <Title headingLevel="h2" size="lg">
+              Loading Jobs
+            </Title>
+            <EmptyStateBody>Fetching scenario runs...</EmptyStateBody>
+          </EmptyState>
+        ) : filteredUnifiedRuns.length === 0 && jobs.length > 0 ? (
           <EmptyState>
             <EmptyStateIcon icon={HiOutlineRocketLaunch} />
             <Title headingLevel="h2" size="lg">
@@ -773,7 +663,7 @@ export function JobsList({
               No scenario runs match the current filter. Try clearing the filter.
             </EmptyStateBody>
           </EmptyState>
-        ) : scenarioRuns.length === 0 ? (
+        ) : jobs.length === 0 ? (
           <EmptyState>
             <EmptyStateIcon icon={HiOutlineRocketLaunch} />
             <Title headingLevel="h2" size="lg">
@@ -1340,6 +1230,22 @@ export function JobsList({
               );
             })}
           </DataList>
+          {pagination.totalPages > 1 && (
+            <Pagination
+              itemCount={pagination.total}
+              perPage={limit}
+              page={page}
+              onSetPage={(_evt, newPage) => setPage(newPage)}
+              onPerPageSelect={(_evt, newPerPage) => { setLimit(newPerPage); setPage(1); }}
+              variant={PaginationVariant.bottom}
+              perPageOptions={[
+                { title: '10', value: 10 },
+                { title: '20', value: 20 },
+                { title: '50', value: 50 },
+              ]}
+              style={{ marginTop: '1rem' }}
+            />
+          )}
           </>
         )}
       </CardBody>

--- a/src/components/JobsList.tsx
+++ b/src/components/JobsList.tsx
@@ -90,10 +90,10 @@ function toUnifiedRunItem(item: UnifiedJobItem): UnifiedRunItem {
       }
       return {
         type: 'graph',
-        graphRunName: gr.name,
+        graphRunName: item.name,
         nodes: [],
         phase,
-        createdAt: gr.creationTimestamp,
+        createdAt: item.createdAt,
         ownerUserId: gr.ownerUserId,
         summary: gr.summary,
         resiliencyScoreEnabled: gr.resiliencyScoreEnabled,
@@ -585,7 +585,7 @@ export function JobsList({
                           onChange={onFromDateChange}
                           validators={[fromValidator]}
                           aria-label="Start date"
-                          placeholder="YYYY-MM-DD"
+                          placeholder="Start date"
                         />
                       </InputGroupItem>
                       <InputGroupItem>
@@ -619,7 +619,7 @@ export function JobsList({
                           rangeStart={dateTimeFrom}
                           validators={[toValidator]}
                           aria-label="End date"
-                          placeholder="YYYY-MM-DD"
+                          placeholder="End date"
                         />
                       </InputGroupItem>
                       <InputGroupItem>

--- a/src/components/JobsList.tsx
+++ b/src/components/JobsList.tsx
@@ -79,29 +79,39 @@ export type UnifiedRunItem =
     }
   | { type: 'scenario'; run: ScenarioRunState };
 
-function toUnifiedRunItem(item: UnifiedJobItem): UnifiedRunItem | null {
-  if (item.type === 'graphRun' && item.graphRun) {
+function toUnifiedRunItem(item: UnifiedJobItem): UnifiedRunItem {
+  if (item.type === 'graphRun') {
     const gr = item.graphRun;
-    let phase: ScenarioRunPhase = 'Pending';
-    if (gr.phase === 'Completed') phase = 'Succeeded';
-    else if (gr.phase === 'Running' || gr.phase === 'Failed' || gr.phase === 'PartiallyFailed' || gr.phase === 'Pending') {
-      phase = gr.phase;
+    if (gr) {
+      let phase: ScenarioRunPhase = 'Pending';
+      if (gr.phase === 'Completed') phase = 'Succeeded';
+      else if (gr.phase === 'Running' || gr.phase === 'Failed' || gr.phase === 'PartiallyFailed' || gr.phase === 'Pending') {
+        phase = gr.phase;
+      }
+      return {
+        type: 'graph',
+        graphRunName: gr.name,
+        nodes: [],
+        phase,
+        createdAt: gr.creationTimestamp,
+        ownerUserId: gr.ownerUserId,
+        summary: gr.summary,
+        resiliencyScoreEnabled: gr.resiliencyScoreEnabled,
+        resiliencyScoreBaseline: gr.resiliencyScoreBaseline,
+        resiliencyScores: gr.resiliencyScores,
+      };
     }
     return {
       type: 'graph',
-      graphRunName: gr.name,
+      graphRunName: item.name,
       nodes: [],
-      phase,
-      createdAt: gr.creationTimestamp,
-      ownerUserId: gr.ownerUserId,
-      summary: gr.summary,
-      resiliencyScoreEnabled: gr.resiliencyScoreEnabled,
-      resiliencyScoreBaseline: gr.resiliencyScoreBaseline,
-      resiliencyScores: gr.resiliencyScores,
+      phase: 'Pending',
+      createdAt: item.createdAt,
+      summary: { totalNodes: 0, completedNodes: 0, runningNodes: 0, failedNodes: 0, pendingNodes: 0 },
     };
   }
-  if (item.type === 'scenarioRun' && item.scenarioRun) {
-    const sr = item.scenarioRun;
+  const sr = item.scenarioRun;
+  if (sr) {
     return {
       type: 'scenario',
       run: {
@@ -121,7 +131,20 @@ function toUnifiedRunItem(item: UnifiedJobItem): UnifiedRunItem | null {
       },
     };
   }
-  return null;
+  return {
+    type: 'scenario',
+    run: {
+      scenarioRunName: item.name,
+      scenarioName: '',
+      phase: 'Pending',
+      totalTargets: 0,
+      successfulJobs: 0,
+      failedJobs: 0,
+      runningJobs: 0,
+      clusterJobs: [],
+      createdAt: item.createdAt,
+    },
+  };
 }
 
 interface JobsListProps {
@@ -343,7 +366,7 @@ export function JobsList({
 
   // Map API items → internal rendering items (server handles merging/sorting/pagination)
   const unifiedRuns = useMemo((): UnifiedRunItem[] => {
-    return jobs.map(toUnifiedRunItem).filter((item): item is UnifiedRunItem => item !== null);
+    return jobs.map(toUnifiedRunItem);
   }, [jobs]);
 
   // Get unique owner user IDs from current page for autocomplete

--- a/src/components/__tests__/JobsList.test.tsx
+++ b/src/components/__tests__/JobsList.test.tsx
@@ -1,6 +1,24 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { GraphRunState, ScenarioRunState } from '../../types/api';
+import type { GraphRunListItem, PaginationMeta, UnifiedJobItem } from '../../types/api';
+
+const mockSetPage = vi.fn();
+const mockSetLimit = vi.fn();
+let mockJobs: UnifiedJobItem[] = [];
+let mockPagination: PaginationMeta = { page: 1, limit: 20, total: 0, totalPages: 0 };
+let mockIsLoading = false;
+
+vi.mock('../../hooks/useJobs', () => ({
+  useJobs: () => ({
+    jobs: mockJobs,
+    pagination: mockPagination,
+    page: mockPagination.page,
+    setPage: mockSetPage,
+    limit: mockPagination.limit,
+    setLimit: mockSetLimit,
+    isLoading: mockIsLoading,
+  }),
+}));
 
 vi.mock('../../hooks/useRole', () => ({
   useRole: () => ({ isAdmin: false, role: 'user' }),
@@ -34,21 +52,58 @@ vi.mock('react-icons/hi2', () => ({
 
 const { JobsList } = await import('../JobsList');
 
-const dummyScenarioRun: ScenarioRunState = {
-  scenarioRunName: 'dummy-run',
-  scenarioName: 'dummy',
-  phase: 'Succeeded' as const,
-  totalTargets: 1,
-  successfulJobs: 1,
-  failedJobs: 0,
-  runningJobs: 0,
-  clusterJobs: [],
+const makeGraphJobItem = (
+  name: string,
+  phase: GraphRunListItem['phase'] = 'Completed',
+  overrides: Partial<GraphRunListItem> = {},
+): UnifiedJobItem => ({
+  type: 'graphRun',
+  name,
+  createdAt: overrides.creationTimestamp || '2026-07-02T08:00:00Z',
+  graphRun: {
+    name,
+    namespace: 'krkn-operator-system',
+    creationTimestamp: '2026-07-02T08:00:00Z',
+    phase,
+    ownerUserId: 'admin@test.com',
+    targetRequestId: 'target-001',
+    summary: { totalNodes: 3, completedNodes: 3, runningNodes: 0, failedNodes: 0, pendingNodes: 0 },
+    resiliencyScoreEnabled: true,
+    resiliencyScoreBaseline: 80.0,
+    resiliencyScores: [
+      { clusterName: 'cluster1', calculated: 87.5, baseline: 80.0, status: 'pass' as const, message: 'Meets baseline', nodeContributions: {} },
+    ],
+    ...overrides,
+  },
+});
+
+const makeScenarioJobItem = (
+  name: string,
+  overrides: Partial<UnifiedJobItem> = {},
+): UnifiedJobItem => ({
+  type: 'scenarioRun',
+  name,
   createdAt: '2026-06-01T00:00:00Z',
-  ownerUserId: 'system@test.com',
-};
+  scenarioRun: {
+    scenarioRunName: name,
+    scenarioName: 'dummy',
+    phase: 'Succeeded',
+    totalTargets: 1,
+    successfulJobs: 1,
+    failedJobs: 0,
+    runningJobs: 0,
+    clusterJobs: [],
+    ownerUserId: 'system@test.com',
+  },
+  ...overrides,
+});
+
+function setMockJobs(items: UnifiedJobItem[]) {
+  mockJobs = items;
+  mockPagination = { page: 1, limit: 20, total: items.length, totalPages: 1 };
+}
 
 const defaultProps = () => ({
-  scenarioRuns: [dummyScenarioRun] as ScenarioRunState[],
   expandedRunIds: new Set<string>(),
   expandedJobIds: new Set<string>(),
   onToggleRunAccordion: vi.fn(),
@@ -57,38 +112,23 @@ const defaultProps = () => ({
   onDeleteJob: vi.fn().mockResolvedValue(undefined),
   onCreateJob: vi.fn(),
   onNavigateToStudio: vi.fn(),
-  graphRuns: [] as GraphRunState[],
   expandedGraphRunIds: new Set<string>(),
   onToggleGraphRunAccordion: vi.fn(),
   onDeleteGraphRun: vi.fn().mockResolvedValue(undefined),
   onRerunScenario: vi.fn(),
 });
 
-const makeGraphRunState = (overrides?: Partial<GraphRunState>): GraphRunState => ({
-  name: 'test-graph-run',
-  namespace: 'krkn-operator-system',
-  creationTimestamp: '2026-07-02T08:00:00Z',
-  phase: 'Completed',
-  ownerUserId: 'admin@test.com',
-  targetRequestId: 'target-001',
-  summary: { totalNodes: 3, completedNodes: 3, runningNodes: 0, failedNodes: 0, pendingNodes: 0 },
-  resiliencyScoreEnabled: true,
-  resiliencyScoreBaseline: 80.0,
-  resiliencyScores: [
-    { clusterName: 'cluster1', calculated: 87.5, baseline: 80.0, status: 'pass' as const, message: 'Meets baseline', nodeContributions: {} },
-  ],
-  ...overrides,
-});
-
 describe('JobsList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockJobs = [];
+    mockPagination = { page: 1, limit: 20, total: 0, totalPages: 0 };
+    mockIsLoading = false;
   });
 
   describe('Empty State', () => {
     it('should show empty state when no runs', () => {
       const props = defaultProps();
-      props.scenarioRuns = [];
       render(<JobsList {...props} />);
       expect(screen.getByText('No Scenario Runs')).toBeInTheDocument();
     });
@@ -96,40 +136,34 @@ describe('JobsList', () => {
 
   describe('GraphRun Rendering', () => {
     it('should render graph run workflow name', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
-      render(<JobsList {...props} />);
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.getByText('test-graph-run')).toBeInTheDocument();
     });
 
     it('should show owner', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
-      render(<JobsList {...props} />);
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.getByText('admin@test.com')).toBeInTheDocument();
     });
 
     it('should show node count', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
-      render(<JobsList {...props} />);
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.getByText('3 / 3')).toBeInTheDocument();
     });
 
     it('should show Succeeded phase label for Completed graph run', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
-      render(<JobsList {...props} />);
+      setMockJobs([makeGraphJobItem('test-graph-run', 'Completed')]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.getAllByText('Succeeded').length).toBeGreaterThanOrEqual(1);
     });
 
     it('should show Running phase for running graph run', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState({
-        phase: 'Running',
+      setMockJobs([makeGraphJobItem('test-graph-run', 'Running', {
         summary: { totalNodes: 3, completedNodes: 1, runningNodes: 1, failedNodes: 0, pendingNodes: 1 },
-      })];
-      render(<JobsList {...props} />);
+      })]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.getByText('Running')).toBeInTheDocument();
       expect(screen.getByText('1 / 3')).toBeInTheDocument();
     });
@@ -137,45 +171,40 @@ describe('JobsList', () => {
 
   describe('Resiliency Score Display', () => {
     it('should show score when enabled with single cluster', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
-      render(<JobsList {...props} />);
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.getByText('87.5')).toBeInTheDocument();
     });
 
     it('should show avg label for multi-cluster scores', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState({
+      setMockJobs([makeGraphJobItem('test-graph-run', 'Completed', {
         resiliencyScores: [
           { clusterName: 'cluster-a', calculated: 90.0, baseline: 80.0, status: 'pass' as const, message: '', nodeContributions: {} },
           { clusterName: 'cluster-b', calculated: 75.0, baseline: 80.0, status: 'fail' as const, message: '', nodeContributions: {} },
         ],
-      })];
-      render(<JobsList {...props} />);
+      })]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.getByText(/\(avg\)/)).toBeInTheDocument();
     });
 
     it('should show Calculating when scores have sentinel value -1', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState({
-        phase: 'Running',
+      setMockJobs([makeGraphJobItem('test-graph-run', 'Running', {
         resiliencyScores: [
           { clusterName: 'cluster-a', calculated: -1, baseline: 80.0, status: 'pass' as const, message: '' },
         ],
         summary: { totalNodes: 3, completedNodes: 0, runningNodes: 1, failedNodes: 0, pendingNodes: 2 },
-      })];
-      render(<JobsList {...props} />);
+      })]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.getByText('Calculating...')).toBeInTheDocument();
     });
 
     it('should show N/A when resiliency not enabled', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState({
+      setMockJobs([makeGraphJobItem('test-graph-run', 'Completed', {
         resiliencyScoreEnabled: false,
         resiliencyScores: undefined,
         resiliencyScoreBaseline: undefined,
-      })];
-      render(<JobsList {...props} />);
+      })]);
+      render(<JobsList {...defaultProps()} />);
       const naElements = screen.getAllByText('N/A');
       expect(naElements.length).toBeGreaterThan(0);
     });
@@ -183,9 +212,8 @@ describe('JobsList', () => {
 
   describe('Delete Confirmation', () => {
     it('should show confirmation modal when delete clicked', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
-      render(<JobsList {...props} />);
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
+      render(<JobsList {...defaultProps()} />);
       const deleteBtn = screen.getByLabelText('Delete graph run');
       fireEvent.click(deleteBtn);
       expect(screen.getByText('Delete Graph Run')).toBeInTheDocument();
@@ -193,8 +221,8 @@ describe('JobsList', () => {
     });
 
     it('should call onDeleteGraphRun on confirm', async () => {
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
       const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
       render(<JobsList {...props} />);
       fireEvent.click(screen.getByLabelText('Delete graph run'));
       fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
@@ -204,9 +232,8 @@ describe('JobsList', () => {
     });
 
     it('should close modal on cancel', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
-      render(<JobsList {...props} />);
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
+      render(<JobsList {...defaultProps()} />);
       fireEvent.click(screen.getByLabelText('Delete graph run'));
       expect(screen.getByText('Delete Graph Run')).toBeInTheDocument();
       fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
@@ -216,8 +243,8 @@ describe('JobsList', () => {
 
   describe('Expand/Collapse', () => {
     it('should call onToggleGraphRunAccordion when toggle clicked', () => {
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
       const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
       render(<JobsList {...props} />);
       const toggle = document.getElementById('toggle-graph-test-graph-run');
       expect(toggle).toBeTruthy();
@@ -226,38 +253,39 @@ describe('JobsList', () => {
     });
 
     it('should render GraphRunDetail when expanded', () => {
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
       const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
       props.expandedGraphRunIds = new Set(['test-graph-run']);
       render(<JobsList {...props} />);
       expect(screen.getByTestId('graph-detail-test-graph-run')).toBeInTheDocument();
     });
 
     it('should not render GraphRunDetail when collapsed', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
-      render(<JobsList {...props} />);
+      setMockJobs([makeGraphJobItem('test-graph-run')]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.queryByTestId('graph-detail-test-graph-run')).not.toBeInTheDocument();
     });
   });
 
   describe('Mixed Runs', () => {
     it('should show both graph runs and standalone scenario runs', () => {
-      const props = defaultProps();
-      props.graphRuns = [makeGraphRunState()];
-      props.scenarioRuns = [{
-        scenarioRunName: 'standalone-run',
-        scenarioName: 'cpu-hog',
-        phase: 'Succeeded' as const,
-        totalTargets: 1,
-        successfulJobs: 1,
-        failedJobs: 0,
-        runningJobs: 0,
-        clusterJobs: [],
-        createdAt: '2026-07-01T08:00:00Z',
-        ownerUserId: 'user@test.com',
-      }];
-      render(<JobsList {...props} />);
+      setMockJobs([
+        makeGraphJobItem('test-graph-run'),
+        makeScenarioJobItem('standalone-run', {
+          scenarioRun: {
+            scenarioRunName: 'standalone-run',
+            scenarioName: 'cpu-hog',
+            phase: 'Succeeded',
+            totalTargets: 1,
+            successfulJobs: 1,
+            failedJobs: 0,
+            runningJobs: 0,
+            clusterJobs: [],
+            ownerUserId: 'user@test.com',
+          },
+        }),
+      ]);
+      render(<JobsList {...defaultProps()} />);
       expect(screen.getByText('test-graph-run')).toBeInTheDocument();
       expect(screen.getByText('cpu-hog')).toBeInTheDocument();
     });

--- a/src/components/__tests__/JobsList.test.tsx
+++ b/src/components/__tests__/JobsList.test.tsx
@@ -1,24 +1,9 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { GraphRunListItem, PaginationMeta, UnifiedJobItem } from '../../types/api';
+import type { GraphRunListItem, UnifiedJobItem } from '../../types/api';
+import { setMockJobs, resetJobsMock } from '../../hooks/__mocks__/useJobs';
 
-const mockSetPage = vi.fn();
-const mockSetLimit = vi.fn();
-let mockJobs: UnifiedJobItem[] = [];
-let mockPagination: PaginationMeta = { page: 1, limit: 20, total: 0, totalPages: 0 };
-let mockIsLoading = false;
-
-vi.mock('../../hooks/useJobs', () => ({
-  useJobs: () => ({
-    jobs: mockJobs,
-    pagination: mockPagination,
-    page: mockPagination.page,
-    setPage: mockSetPage,
-    limit: mockPagination.limit,
-    setLimit: mockSetLimit,
-    isLoading: mockIsLoading,
-  }),
-}));
+vi.mock('../../hooks/useJobs');
 
 vi.mock('../../hooks/useRole', () => ({
   useRole: () => ({ isAdmin: false, role: 'user' }),
@@ -98,11 +83,6 @@ const makeScenarioJobItem = (
   ...overrides,
 });
 
-function setMockJobs(items: UnifiedJobItem[]) {
-  mockJobs = items;
-  mockPagination = { page: 1, limit: 20, total: items.length, totalPages: 1 };
-}
-
 const defaultProps = () => ({
   expandedRunIds: new Set<string>(),
   expandedJobIds: new Set<string>(),
@@ -121,9 +101,7 @@ const defaultProps = () => ({
 describe('JobsList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockJobs = [];
-    mockPagination = { page: 1, limit: 20, total: 0, totalPages: 0 };
-    mockIsLoading = false;
+    resetJobsMock();
   });
 
   describe('Empty State', () => {

--- a/src/hooks/__mocks__/useJobs.ts
+++ b/src/hooks/__mocks__/useJobs.ts
@@ -1,0 +1,45 @@
+import { vi } from 'vitest';
+import type { UnifiedJobItem, PaginationMeta } from '../../types/api';
+
+const state = {
+  jobs: [] as UnifiedJobItem[],
+  pagination: { page: 1, limit: 20, total: 0, totalPages: 0 } as PaginationMeta,
+  isLoading: false,
+  setPage: vi.fn(),
+  setLimit: vi.fn(),
+};
+
+export function useJobs() {
+  return {
+    jobs: state.jobs,
+    pagination: state.pagination,
+    page: state.pagination.page,
+    setPage: state.setPage,
+    limit: state.pagination.limit,
+    setLimit: state.setLimit,
+    isLoading: state.isLoading,
+  };
+}
+
+export function setMockJobs(items: UnifiedJobItem[]) {
+  state.jobs = items;
+  state.pagination = { page: 1, limit: 20, total: items.length, totalPages: 1 };
+}
+
+export function setMockPagination(pagination: PaginationMeta) {
+  state.pagination = pagination;
+}
+
+export function setMockIsLoading(loading: boolean) {
+  state.isLoading = loading;
+}
+
+export function resetJobsMock() {
+  state.jobs = [];
+  state.pagination = { page: 1, limit: 20, total: 0, totalPages: 0 };
+  state.isLoading = false;
+  state.setPage.mockClear();
+  state.setLimit.mockClear();
+}
+
+export { state as _mockState };

--- a/src/hooks/__tests__/useJobs.test.tsx
+++ b/src/hooks/__tests__/useJobs.test.tsx
@@ -1,18 +1,14 @@
-import { renderHook, act, waitFor } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ServerMessage } from '../../types/websocket';
-import type { UnifiedJobsResponse } from '../../types/api';
-
-vi.mock('../../services/operatorApi');
 
 let capturedHandler: ((msg: ServerMessage) => void) | null = null;
 const mockConnectionState = { value: 'disconnected' as string };
-const mockSubscribe = vi.fn();
 
 vi.mock('../useWebSocket', () => ({
   useWebSocket: (_id: string, _url: string, handler: (msg: ServerMessage) => void) => {
     capturedHandler = handler;
-    return { connectionState: mockConnectionState.value, subscribe: mockSubscribe, unsubscribe: vi.fn() };
+    return { connectionState: mockConnectionState.value };
   },
 }));
 
@@ -23,235 +19,124 @@ vi.mock('../../services/websocketService', () => ({
   },
 }));
 
-import { operatorApi } from '../../services/operatorApi';
 import { websocketService } from '../../services/websocketService';
 import { useJobs } from '../useJobs';
 
-const mockJobsResponse: UnifiedJobsResponse = {
-  jobs: [
-    { type: 'scenarioRun', name: 'run-001', createdAt: '2026-08-01T10:00:00Z' },
-    { type: 'graphRun', name: 'graph-001', createdAt: '2026-08-01T09:00:00Z' },
-  ],
-  pagination: { page: 1, limit: 20, total: 2, totalPages: 1 },
+function sendWsSnapshot(jobs: unknown[], pagination = { page: 1, limit: 20, total: jobs.length, totalPages: 1 }) {
+  act(() => {
+    capturedHandler?.({
+      resource: 'jobs',
+      id: '',
+      event: 'snapshot',
+      data: { jobs },
+      pagination,
+    });
+  });
+}
+
+const scenarioJob = {
+  type: 'scenarioRun', name: 'run-001', createdAt: '2026-08-01T10:00:00Z',
+  scenarioRun: { scenarioRunName: 'run-001', scenarioName: 'cpu-hog', phase: 'Succeeded', totalTargets: 1, successfulJobs: 1, failedJobs: 0, runningJobs: 0, clusterJobs: [{ providerName: 'p1', clusterName: 'c1', jobId: 'j1', podName: 'pod1', phase: 'Succeeded' }] },
 };
 
-function sendWsMessage(msg: ServerMessage) {
-  act(() => { capturedHandler?.(msg); });
-}
+const graphJob = {
+  type: 'graphRun', name: 'graph-001', createdAt: '2026-08-01T09:00:00Z',
+  graphRun: { name: 'graph-001', phase: 'Completed', summary: { totalNodes: 2, completedNodes: 2, runningNodes: 0, failedNodes: 0, pendingNodes: 0 }, resiliencyScoreEnabled: true, resiliencyScoreBaseline: 80 },
+};
 
 describe('useJobs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     capturedHandler = null;
     mockConnectionState.value = 'connected';
-    vi.mocked(operatorApi.listUnifiedJobs).mockResolvedValue(mockJobsResponse);
   });
 
-  it('fetches initial jobs on connect', async () => {
+  it('subscribes to WS with page and limit on connect', () => {
     renderHook(() => useJobs());
 
-    await waitFor(() => {
-      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(1, 20);
-    });
+    expect(websocketService.subscribe).toHaveBeenCalledWith('jobs', 'jobs', undefined, 1, 20);
   });
 
-  it('subscribes to WS with page and limit', async () => {
-    renderHook(() => useJobs());
-
-    await waitFor(() => {
-      expect(websocketService.subscribe).toHaveBeenCalledWith('jobs', 'jobs', undefined, 1, 20);
-    });
-  });
-
-  it('exposes jobs and pagination from REST response', async () => {
-    const { result } = renderHook(() => useJobs());
-
-    await waitFor(() => {
-      expect(result.current.jobs).toHaveLength(2);
-    });
-
-    expect(result.current.jobs[0].name).toBe('run-001');
-    expect(result.current.pagination.total).toBe(2);
-    expect(result.current.pagination.totalPages).toBe(1);
-  });
-
-  it('updates jobs on WS snapshot event', async () => {
-    const { result } = renderHook(() => useJobs());
-
-    await waitFor(() => {
-      expect(result.current.jobs).toHaveLength(2);
-    });
-
-    sendWsMessage({
-      resource: 'jobs',
-      id: '',
-      event: 'snapshot',
-      data: {
-        jobs: [
-          {
-            type: 'scenarioRun', name: 'run-002', createdAt: '2026-08-02T10:00:00Z',
-            scenarioRun: { scenarioRunName: 'run-002', phase: 'Running', totalTargets: 1, successfulJobs: 0, failedJobs: 0, runningJobs: 1, clusterJobs: [] },
-          },
-        ],
-      },
-      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
-    });
-
-    expect(result.current.jobs).toHaveLength(1);
-    expect(result.current.jobs[0].name).toBe('run-002');
-    expect(result.current.pagination.total).toBe(1);
-  });
-
-  it('falls back to REST fetch when snapshot has incomplete payloads', async () => {
-    const { result } = renderHook(() => useJobs());
-
-    await waitFor(() => {
-      expect(result.current.jobs).toHaveLength(2);
-    });
-
-    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
-
-    sendWsMessage({
-      resource: 'jobs',
-      id: '',
-      event: 'snapshot',
-      data: {
-        jobs: [
-          { type: 'scenarioRun', name: 'run-incomplete', createdAt: '2026-08-02T10:00:00Z' },
-        ],
-      },
-      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
-    });
-
-    expect(result.current.pagination.total).toBe(1);
-
-    await waitFor(() => {
-      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(1, 20);
-    });
-  });
-
-  it('re-fetches on WS created event', async () => {
-    const { result } = renderHook(() => useJobs());
-
-    await waitFor(() => {
-      expect(result.current.jobs).toHaveLength(2);
-    });
-
-    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
-
-    sendWsMessage({
-      resource: 'jobs',
-      id: 'run-003',
-      event: 'created',
-      data: {},
-    });
-
-    await waitFor(() => {
-      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(1, 20);
-    });
-  });
-
-  it('re-fetches on WS deleted event', async () => {
-    const { result } = renderHook(() => useJobs());
-
-    await waitFor(() => {
-      expect(result.current.jobs).toHaveLength(2);
-    });
-
-    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
-
-    sendWsMessage({
-      resource: 'jobs',
-      id: 'run-001',
-      event: 'deleted',
-      data: {},
-    });
-
-    await waitFor(() => {
-      expect(operatorApi.listUnifiedJobs).toHaveBeenCalled();
-    });
-  });
-
-  it('ignores messages for other resources', async () => {
-    const { result } = renderHook(() => useJobs());
-
-    await waitFor(() => {
-      expect(result.current.jobs).toHaveLength(2);
-    });
-
-    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
-
-    sendWsMessage({
-      resource: 'run',
-      id: 'run-001',
-      event: 'updated',
-      data: {},
-    });
-
-    expect(operatorApi.listUnifiedJobs).not.toHaveBeenCalled();
-  });
-
-  it('re-subscribes when page changes', async () => {
-    const { result } = renderHook(() => useJobs());
-
-    await waitFor(() => {
-      expect(result.current.jobs).toHaveLength(2);
-    });
-
-    vi.mocked(websocketService.subscribe).mockClear();
-    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
-
-    act(() => { result.current.setPage(2); });
-
-    await waitFor(() => {
-      expect(websocketService.subscribe).toHaveBeenCalledWith('jobs', 'jobs', undefined, 2, 20);
-      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(2, 20);
-    });
-  });
-
-  it('re-subscribes when limit changes', async () => {
-    const { result } = renderHook(() => useJobs());
-
-    await waitFor(() => {
-      expect(result.current.jobs).toHaveLength(2);
-    });
-
-    vi.mocked(websocketService.subscribe).mockClear();
-    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
-
-    act(() => { result.current.setLimit(50); });
-
-    await waitFor(() => {
-      expect(websocketService.subscribe).toHaveBeenCalledWith('jobs', 'jobs', undefined, 1, 50);
-      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(1, 50);
-    });
-  });
-
-  it('does not fetch when disconnected', () => {
+  it('does not subscribe when disconnected', () => {
     mockConnectionState.value = 'disconnected';
     renderHook(() => useJobs());
 
-    expect(operatorApi.listUnifiedJobs).not.toHaveBeenCalled();
+    expect(websocketService.subscribe).not.toHaveBeenCalled();
   });
 
-  it('sets isLoading during fetch', async () => {
-    let resolvePromise: (v: UnifiedJobsResponse) => void;
-    vi.mocked(operatorApi.listUnifiedJobs).mockImplementation(
-      () => new Promise(r => { resolvePromise = r; })
-    );
-
+  it('starts with isLoading true', () => {
     const { result } = renderHook(() => useJobs());
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(true);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.jobs).toHaveLength(0);
+  });
+
+  it('populates jobs from WS snapshot', () => {
+    const { result } = renderHook(() => useJobs());
+
+    sendWsSnapshot([scenarioJob, graphJob]);
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.jobs).toHaveLength(2);
+    expect(result.current.jobs[0].name).toBe('run-001');
+    expect(result.current.jobs[0].scenarioRun!.clusterJobs).toHaveLength(1);
+    expect(result.current.jobs[1].name).toBe('graph-001');
+    expect(result.current.pagination.total).toBe(2);
+  });
+
+  it('replaces jobs on subsequent WS snapshots', () => {
+    const { result } = renderHook(() => useJobs());
+
+    sendWsSnapshot([scenarioJob, graphJob]);
+    expect(result.current.jobs).toHaveLength(2);
+
+    sendWsSnapshot([scenarioJob]);
+    expect(result.current.jobs).toHaveLength(1);
+    expect(result.current.pagination.total).toBe(1);
+  });
+
+  it('ignores messages for other resources', () => {
+    const { result } = renderHook(() => useJobs());
+
+    sendWsSnapshot([scenarioJob]);
+    expect(result.current.jobs).toHaveLength(1);
+
+    act(() => {
+      capturedHandler?.({ resource: 'run', id: 'run-001', event: 'updated', data: {} });
     });
 
-    await act(async () => {
-      resolvePromise!(mockJobsResponse);
-    });
+    expect(result.current.jobs).toHaveLength(1);
+  });
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-    });
+  it('re-subscribes when page changes', () => {
+    const { result } = renderHook(() => useJobs());
+
+    sendWsSnapshot([scenarioJob]);
+    vi.mocked(websocketService.subscribe).mockClear();
+
+    act(() => { result.current.setPage(2); });
+
+    expect(websocketService.subscribe).toHaveBeenCalledWith('jobs', 'jobs', undefined, 2, 20);
+  });
+
+  it('re-subscribes when limit changes', () => {
+    const { result } = renderHook(() => useJobs());
+
+    sendWsSnapshot([scenarioJob]);
+    vi.mocked(websocketService.subscribe).mockClear();
+
+    act(() => { result.current.setLimit(50); });
+
+    expect(websocketService.subscribe).toHaveBeenCalledWith('jobs', 'jobs', undefined, 1, 50);
+  });
+
+  it('sets isLoading true on re-subscribe', () => {
+    const { result } = renderHook(() => useJobs());
+
+    sendWsSnapshot([scenarioJob]);
+    expect(result.current.isLoading).toBe(false);
+
+    act(() => { result.current.setPage(2); });
+    expect(result.current.isLoading).toBe(true);
   });
 });

--- a/src/hooks/__tests__/useJobs.test.tsx
+++ b/src/hooks/__tests__/useJobs.test.tsx
@@ -88,7 +88,10 @@ describe('useJobs', () => {
       event: 'snapshot',
       data: {
         jobs: [
-          { type: 'scenarioRun', name: 'run-002', createdAt: '2026-08-02T10:00:00Z' },
+          {
+            type: 'scenarioRun', name: 'run-002', createdAt: '2026-08-02T10:00:00Z',
+            scenarioRun: { scenarioRunName: 'run-002', phase: 'Running', totalTargets: 1, successfulJobs: 0, failedJobs: 0, runningJobs: 1, clusterJobs: [] },
+          },
         ],
       },
       pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
@@ -97,6 +100,34 @@ describe('useJobs', () => {
     expect(result.current.jobs).toHaveLength(1);
     expect(result.current.jobs[0].name).toBe('run-002');
     expect(result.current.pagination.total).toBe(1);
+  });
+
+  it('falls back to REST fetch when snapshot has incomplete payloads', async () => {
+    const { result } = renderHook(() => useJobs());
+
+    await waitFor(() => {
+      expect(result.current.jobs).toHaveLength(2);
+    });
+
+    vi.mocked(operatorApi.listUnifiedJobs).mockClear();
+
+    sendWsMessage({
+      resource: 'jobs',
+      id: '',
+      event: 'snapshot',
+      data: {
+        jobs: [
+          { type: 'scenarioRun', name: 'run-incomplete', createdAt: '2026-08-02T10:00:00Z' },
+        ],
+      },
+      pagination: { page: 1, limit: 20, total: 1, totalPages: 1 },
+    });
+
+    expect(result.current.pagination.total).toBe(1);
+
+    await waitFor(() => {
+      expect(operatorApi.listUnifiedJobs).toHaveBeenCalledWith(1, 20);
+    });
   });
 
   it('re-fetches on WS created event', async () => {

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -66,15 +66,21 @@ export function useJobs(): UseJobsReturn {
 
     if (message.event === 'snapshot') {
       const data = message.data as { jobs?: UnifiedJobItem[] };
-      if (data.jobs) {
+      const hasFullPayloads = data.jobs?.every(
+        j => (j.type === 'scenarioRun' && j.scenarioRun) || (j.type === 'graphRun' && j.graphRun)
+      );
+      if (data.jobs && hasFullPayloads) {
         setJobs(data.jobs);
+        if (message.pagination) {
+          setPagination(message.pagination);
+        }
+      } else {
+        if (message.pagination) {
+          setPagination(message.pagination);
+        }
+        fetchJobs(pageRef.current, limitRef.current);
       }
-      if (message.pagination) {
-        setPagination(message.pagination);
-      }
-    } else if (message.event === 'created' || message.event === 'updated') {
-      fetchJobs(pageRef.current, limitRef.current);
-    } else if (message.event === 'deleted') {
+    } else if (message.event === 'created' || message.event === 'updated' || message.event === 'deleted') {
       fetchJobs(pageRef.current, limitRef.current);
     }
   }, [fetchJobs]);

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -1,9 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { operatorApi } from '../services/operatorApi';
 import { useWebSocket } from './useWebSocket';
 import { websocketService } from '../services/websocketService';
 import type { ServerMessage, PaginationMeta } from '../types/websocket';
-import type { UnifiedJobItem, UnifiedJobsResponse } from '../types/api';
+import type { UnifiedJobItem } from '../types/api';
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 20;
@@ -20,88 +19,52 @@ interface UseJobsReturn {
 }
 
 /**
- * Hook providing a unified paginated jobs list via REST + WebSocket.
+ * Hook providing a unified paginated jobs list via WebSocket.
  *
- * On mount: fetches the initial page via REST.
- * Subscribes to WS resource 'jobs' with page/limit for real-time snapshots.
- * When page or limit changes, re-subscribes and re-fetches.
+ * Subscribes to WS resource 'jobs' with page/limit.
+ * Backend sends a snapshot automatically on subscribe and on every change.
+ * When page or limit changes, re-subscribes to get the new page.
  */
 export function useJobs(): UseJobsReturn {
   const [jobs, setJobs] = useState<UnifiedJobItem[]>([]);
   const [pagination, setPagination] = useState<PaginationMeta>(EMPTY_PAGINATION);
   const [page, setPage] = useState(DEFAULT_PAGE);
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
-  const pageRef = useRef(page);
-  const limitRef = useRef(limit);
-  pageRef.current = page;
-  limitRef.current = limit;
-
-  const requestIdRef = useRef(0);
-  const lastFetchedRef = useRef<string | null>(null);
-
-  const fetchJobs = useCallback(async (p: number, l: number) => {
-    const requestId = ++requestIdRef.current;
-    setIsLoading(true);
-    try {
-      const data: UnifiedJobsResponse = await operatorApi.listUnifiedJobs(p, l);
-      if (requestId !== requestIdRef.current) return;
-      setJobs(data.jobs);
-      if (data.pagination.page !== p) setPage(data.pagination.page);
-      if (data.pagination.limit !== l) setLimit(data.pagination.limit);
-      setPagination(data.pagination);
-    } catch (err) {
-      if (requestId !== requestIdRef.current) return;
-      console.error('Failed to fetch jobs:', err);
-    } finally {
-      if (requestId === requestIdRef.current) {
-        setIsLoading(false);
-      }
-    }
-  }, []);
+  const lastSubscribedRef = useRef<string | null>(null);
 
   const handleMessage = useCallback((message: ServerMessage) => {
     if (message.resource !== 'jobs') return;
 
     if (message.event === 'snapshot') {
       const data = message.data as { jobs?: UnifiedJobItem[] };
-      const hasFullPayloads = data.jobs?.every(
-        j => (j.type === 'scenarioRun' && j.scenarioRun) || (j.type === 'graphRun' && j.graphRun)
-      );
-      if (data.jobs && hasFullPayloads) {
+      if (data.jobs) {
         setJobs(data.jobs);
+        setIsLoading(false);
         if (message.pagination) {
           setPagination(message.pagination);
         }
-      } else {
-        if (message.pagination) {
-          setPagination(message.pagination);
-        }
-        fetchJobs(pageRef.current, limitRef.current);
       }
-    } else if (message.event === 'created' || message.event === 'updated' || message.event === 'deleted') {
-      fetchJobs(pageRef.current, limitRef.current);
     }
-  }, [fetchJobs]);
+  }, []);
 
   const wsUrl = websocketService.buildResourceUrl('runs');
   const { connectionState } = useWebSocket('jobs', wsUrl, handleMessage);
 
-  // Fetch + subscribe on connect and when page/limit changes
   useEffect(() => {
     if (connectionState !== 'connected') {
-      lastFetchedRef.current = null;
+      lastSubscribedRef.current = null;
       return;
     }
 
     const key = `${page}:${limit}`;
-    if (lastFetchedRef.current === key) return;
-    lastFetchedRef.current = key;
+    if (lastSubscribedRef.current === key) return;
+    lastSubscribedRef.current = key;
 
-    fetchJobs(page, limit);
+    setIsLoading(true);
     websocketService.subscribe('jobs', 'jobs', undefined, page, limit);
-  }, [connectionState, page, limit, fetchJobs]);
+  }, [connectionState, page, limit]);
 
   return { jobs, pagination, page, setPage, limit, setLimit, isLoading };
 }

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -33,22 +33,31 @@ export function useJobs(): UseJobsReturn {
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
   const [isLoading, setIsLoading] = useState(false);
 
-  const initialFetchDoneRef = useRef(false);
   const pageRef = useRef(page);
   const limitRef = useRef(limit);
   pageRef.current = page;
   limitRef.current = limit;
 
+  const requestIdRef = useRef(0);
+  const lastFetchedRef = useRef<string | null>(null);
+
   const fetchJobs = useCallback(async (p: number, l: number) => {
+    const requestId = ++requestIdRef.current;
     setIsLoading(true);
     try {
       const data: UnifiedJobsResponse = await operatorApi.listUnifiedJobs(p, l);
+      if (requestId !== requestIdRef.current) return;
       setJobs(data.jobs);
+      if (data.pagination.page !== p) setPage(data.pagination.page);
+      if (data.pagination.limit !== l) setLimit(data.pagination.limit);
       setPagination(data.pagination);
-    } catch {
-      // Keep existing state on error
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      console.error('Failed to fetch jobs:', err);
     } finally {
-      setIsLoading(false);
+      if (requestId === requestIdRef.current) {
+        setIsLoading(false);
+      }
     }
   }, []);
 
@@ -64,7 +73,6 @@ export function useJobs(): UseJobsReturn {
         setPagination(message.pagination);
       }
     } else if (message.event === 'created' || message.event === 'updated') {
-      // Individual item update — re-fetch current page for consistency
       fetchJobs(pageRef.current, limitRef.current);
     } else if (message.event === 'deleted') {
       fetchJobs(pageRef.current, limitRef.current);
@@ -74,27 +82,20 @@ export function useJobs(): UseJobsReturn {
   const wsUrl = websocketService.buildResourceUrl('runs');
   const { connectionState } = useWebSocket('jobs', wsUrl, handleMessage);
 
-  // Initial fetch + subscribe on connect
+  // Fetch + subscribe on connect and when page/limit changes
   useEffect(() => {
     if (connectionState !== 'connected') {
-      initialFetchDoneRef.current = false;
+      lastFetchedRef.current = null;
       return;
     }
-    if (initialFetchDoneRef.current) return;
-    initialFetchDoneRef.current = true;
+
+    const key = `${page}:${limit}`;
+    if (lastFetchedRef.current === key) return;
+    lastFetchedRef.current = key;
 
     fetchJobs(page, limit);
     websocketService.subscribe('jobs', 'jobs', undefined, page, limit);
   }, [connectionState, page, limit, fetchJobs]);
-
-  // Re-subscribe + re-fetch when page or limit changes
-  useEffect(() => {
-    if (connectionState !== 'connected') return;
-    if (!initialFetchDoneRef.current) return;
-
-    fetchJobs(page, limit);
-    websocketService.subscribe('jobs', 'jobs', undefined, page, limit);
-  }, [page, limit, connectionState, fetchJobs]);
 
   return { jobs, pagination, page, setPage, limit, setLimit, isLoading };
 }

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -33,31 +33,22 @@ export function useJobs(): UseJobsReturn {
   const [limit, setLimit] = useState(DEFAULT_LIMIT);
   const [isLoading, setIsLoading] = useState(false);
 
+  const initialFetchDoneRef = useRef(false);
   const pageRef = useRef(page);
   const limitRef = useRef(limit);
   pageRef.current = page;
   limitRef.current = limit;
 
-  const requestIdRef = useRef(0);
-  const lastFetchedRef = useRef<string | null>(null);
-
   const fetchJobs = useCallback(async (p: number, l: number) => {
-    const requestId = ++requestIdRef.current;
     setIsLoading(true);
     try {
       const data: UnifiedJobsResponse = await operatorApi.listUnifiedJobs(p, l);
-      if (requestId !== requestIdRef.current) return;
       setJobs(data.jobs);
-      if (data.pagination.page !== p) setPage(data.pagination.page);
-      if (data.pagination.limit !== l) setLimit(data.pagination.limit);
       setPagination(data.pagination);
-    } catch (err) {
-      if (requestId !== requestIdRef.current) return;
-      console.error('Failed to fetch jobs:', err);
+    } catch {
+      // Keep existing state on error
     } finally {
-      if (requestId === requestIdRef.current) {
-        setIsLoading(false);
-      }
+      setIsLoading(false);
     }
   }, []);
 
@@ -73,6 +64,7 @@ export function useJobs(): UseJobsReturn {
         setPagination(message.pagination);
       }
     } else if (message.event === 'created' || message.event === 'updated') {
+      // Individual item update — re-fetch current page for consistency
       fetchJobs(pageRef.current, limitRef.current);
     } else if (message.event === 'deleted') {
       fetchJobs(pageRef.current, limitRef.current);
@@ -82,20 +74,27 @@ export function useJobs(): UseJobsReturn {
   const wsUrl = websocketService.buildResourceUrl('runs');
   const { connectionState } = useWebSocket('jobs', wsUrl, handleMessage);
 
-  // Fetch + subscribe on connect and when page/limit changes
+  // Initial fetch + subscribe on connect
   useEffect(() => {
     if (connectionState !== 'connected') {
-      lastFetchedRef.current = null;
+      initialFetchDoneRef.current = false;
       return;
     }
-
-    const key = `${page}:${limit}`;
-    if (lastFetchedRef.current === key) return;
-    lastFetchedRef.current = key;
+    if (initialFetchDoneRef.current) return;
+    initialFetchDoneRef.current = true;
 
     fetchJobs(page, limit);
     websocketService.subscribe('jobs', 'jobs', undefined, page, limit);
   }, [connectionState, page, limit, fetchJobs]);
+
+  // Re-subscribe + re-fetch when page or limit changes
+  useEffect(() => {
+    if (connectionState !== 'connected') return;
+    if (!initialFetchDoneRef.current) return;
+
+    fetchJobs(page, limit);
+    websocketService.subscribe('jobs', 'jobs', undefined, page, limit);
+  }, [page, limit, connectionState, fetchJobs]);
 
   return { jobs, pagination, page, setPage, limit, setLimit, isLoading };
 }


### PR DESCRIPTION
## Summary

- Refactor `JobsList` to use the `useJobs()` hook (from PR #81) instead of receiving `scenarioRuns`/`graphRuns` as props
- Remove ~150 lines of client-side merge/sort logic — the server now handles pagination and ordering via the unified `/api/v2/jobs` endpoint
- Add PatternFly `Pagination` component below the DataList with per-page options (10, 20, 50)
- Add loading empty state with spinner while initial data loads
- Keep client-side filters (owner, date range, run name) for filtering within the current page
- Update `App.tsx` to remove `scenarioRuns`/`graphRuns` props from the `<JobsList>` call
- Rewrite all JobsList tests to mock `useJobs` instead of passing data via props

## Test plan

- [x] All 816 tests pass across 58 test files
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Pagination hidden when single page, visible when multi-page
- [x] Loading state displayed while fetching
- [ ] Manual: verify pagination controls navigate between pages
- [ ] Manual: verify per-page selector changes item count
- [ ] Manual: verify client-side filters work on paginated data

## Dependencies

- Depends on PR #81 (pagination foundation: WS types, `listUnifiedJobs`, `useJobs` hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)